### PR TITLE
fix: detect AppsyncFunction via a static property instead of class name

### DIFF
--- a/src/appsync.ts
+++ b/src/appsync.ts
@@ -61,6 +61,11 @@ export class AppsyncFunction<
   F extends AnyFunction = AnyFunction,
   Source = undefined
 > {
+  /**
+   * This static property identifies this class as an AppsyncFunction to the TypeScript plugin.
+   */
+  public static readonly FunctionlessType = "AppsyncFunction";
+
   public readonly decl: FunctionDecl<F>;
 
   constructor(


### PR DESCRIPTION
The logic for detecting (and then transforming) `new AppsyncFunction` was naive. It would transform any class named `AppsyncFunction`, which would have conflicted with `@aws-cdk/aws-appsync-alpha`.

As of this change, the compiler now looks for a static property, `FunctionlessType`.

```ts
export class AppsyncFunction {
  public static readonly FunctionlessType = "AppsyncFunction";
}
```