### PR TITLE
feat: rename AppsyncFunction to AppsyncResolver and move arguments to $context.arguments

### DIFF
--- a/src/compile.ts
+++ b/src/compile.ts
@@ -12,7 +12,7 @@ export default compile;
 export interface FunctionlessConfig extends PluginConfig {}
 
 /**
- * TypeScript Transformer which transforms functionless functions, such as `appsyncFunction`,
+ * TypeScript Transformer which transforms functionless functions, such as `AppsyncResolver`,
  * into an AST that can be interpreted at CDK synth time to produce VTL templates and AppSync
  * Resolver configurations.
  *
@@ -55,8 +55,8 @@ export function compile(
       );
 
       function visitor(node: ts.Node): ts.Node {
-        if (isAppsyncFunction(node)) {
-          return visitAppsyncFunction(node);
+        if (isAppsyncResolver(node)) {
+          return visitAppsyncResolver(node);
         } else if (isReflectFunction(node)) {
           return toFunction("FunctionDecl", node.arguments[0]);
         }
@@ -81,12 +81,12 @@ export function compile(
         return false;
       }
 
-      function isAppsyncFunction(node: ts.Node): node is ts.NewExpression {
+      function isAppsyncResolver(node: ts.Node): node is ts.NewExpression {
         if (ts.isNewExpression(node)) {
           const exprType = checker.getTypeAtLocation(node.expression);
           const exprDecl = exprType.symbol?.declarations?.[0];
           if (exprDecl && ts.isClassDeclaration(exprDecl)) {
-            return getFunctionlessKind(exprDecl) === "AppsyncFunction";
+            return getFunctionlessKind(exprDecl) === "AppsyncResolver";
           }
         }
         return false;
@@ -117,7 +117,7 @@ export function compile(
         return undefined;
       }
 
-      function visitAppsyncFunction(call: ts.NewExpression): ts.Node {
+      function visitAppsyncResolver(call: ts.NewExpression): ts.Node {
         if (call.arguments?.length === 1) {
           const impl = call.arguments[0];
           if (ts.isFunctionExpression(impl) || ts.isArrowFunction(impl)) {

--- a/src/function.ts
+++ b/src/function.ts
@@ -3,7 +3,7 @@ import { CallExpr } from "./expression";
 import { VTL } from "./vtl";
 
 // @ts-ignore - imported for typedoc
-import type { AppsyncFunction } from "./appsync";
+import type { AppsyncResolver } from "./appsync";
 
 export type AnyFunction = (...args: any[]) => any;
 
@@ -15,7 +15,7 @@ export type AnyLambda = Function<AnyFunction>;
 
 /**
  * Wraps an {@link aws_lambda.Function} with a type-safe interface that can be
- * called from within an {@link AppsyncFunction}.
+ * called from within an {@link AppsyncResolver}.
  *
  * For example:
  * ```ts
@@ -23,7 +23,7 @@ export type AnyLambda = Function<AnyFunction>;
  *   new aws_lambda.Function(..)
  * );
  *
- * new AppsyncFunction(() => {
+ * new AppsyncResolver(() => {
  *   return getPerson("value");
  * })
  * ```

--- a/src/table.ts
+++ b/src/table.ts
@@ -10,7 +10,7 @@ import { CallExpr } from "./expression";
 import { VTL } from "./vtl";
 
 // @ts-ignore - imported for typedoc
-import type { AppsyncFunction } from "./appsync";
+import type { AppsyncResolver } from "./appsync";
 
 export function isTable(a: any): a is AnyTable {
   return a?.kind === "Table";
@@ -20,7 +20,7 @@ export type AnyTable = Table<object, keyof object, keyof object | undefined>;
 
 /**
  * Wraps an {@link aws_dynamodb.Table} with a type-safe interface that can be
- * called from within an {@link AppsyncFunction}.
+ * called from within an {@link AppsyncResolver}.
  *
  * Its interface, e.g. `getItem`, `putItem`, is in 1:1 correspondence with the
  * AWS Appsync Resolver API https://docs.aws.amazon.com/appsync/latest/devguide/resolver-mapping-template-reference-dynamodb.html
@@ -37,7 +37,7 @@ export type AnyTable = Table<object, keyof object, keyof object | undefined>;
  *   new aws_dynamodb.Table(..)
  * );
  *
- * const getPerson = new AppsyncFunction<
+ * const getPerson = new AppsyncResolver<
  *   (personId: string) => Person | undefined
  * >(($context, personId: string) => {
  *   const person = personTable.get({

--- a/src/util.ts
+++ b/src/util.ts
@@ -52,7 +52,7 @@ export function findService(
 //   return Array.from(new Array(depth)).join(" ");
 // }
 
-// derives a name from an expression - this can be used to name infrastructure, such as an AppsyncFunction.
+// derives a name from an expression - this can be used to name infrastructure, such as an AppsyncResolver.
 // e.g. table.getItem(..) => "table_getItem"
 export function toName(expr: FunctionlessNode): string {
   if (expr.kind === "Identifier") {

--- a/src/vtl.ts
+++ b/src/vtl.ts
@@ -316,7 +316,8 @@ export class VTL {
         ref?.kind === "ParameterDecl" &&
         ref.parent?.kind === "FunctionDecl"
       ) {
-        return `$context.arguments.${ref.name}`;
+        // regardless of the name of the first argument in the root FunctionDecl, it is always the intrinsic Appsync `$context`.
+        return "$context";
       }
       if (node.name.startsWith("$")) {
         return node.name;

--- a/test/function.test.ts
+++ b/test/function.test.ts
@@ -1,5 +1,5 @@
 import "jest";
-import { reflect } from "../src";
+import { AppsyncContext, reflect } from "../src";
 import { Function } from "../src";
 import { returnExpr, testCase } from "./util";
 
@@ -13,8 +13,8 @@ const fn2 = new Function<(arg: string, optional?: string) => Item>(null as any);
 
 test("call function", () =>
   testCase(
-    reflect((arg: string) => {
-      return fn1(arg);
+    reflect((context: AppsyncContext<{ arg: string }>) => {
+      return fn1(context.arguments.arg);
     }),
     `#set($v1 = {})
 $util.qr($v1.put('arg', $context.arguments.arg))
@@ -24,8 +24,8 @@ ${returnExpr("$util.toJson($v2)")}`
 
 test("call function omitting optional arg", () =>
   testCase(
-    reflect((arg: string) => {
-      return fn2(arg);
+    reflect((context: AppsyncContext<{ arg: string }>) => {
+      return fn2(context.arguments.arg);
     }),
     `#set($v1 = {})
 $util.qr($v1.put('arg', $context.arguments.arg))
@@ -36,8 +36,8 @@ ${returnExpr("$util.toJson($v2)")}`
 
 test("call function including optional arg", () =>
   testCase(
-    reflect((arg: string) => {
-      return fn2(arg, "hello");
+    reflect((context: AppsyncContext<{ arg: string }>) => {
+      return fn2(context.arguments.arg, "hello");
     }),
     `#set($v1 = {})
 $util.qr($v1.put('arg', $context.arguments.arg))


### PR DESCRIPTION
Fixes #24
Fixes #25

This Pull Request makes changes to the type signature and name of an `AppsyncFunction`:

* Renames `AppsyncFunction` to `AppsyncResolver`. This aligns with AWS Appsync's terminology - technically a Resolver is a collection of 0-many Functions. It also addresses some of the naming concerns that are coming as we implement other services such as Step Functions, see https://github.com/sam-goodwin/functionless/issues/7#issuecomment-1057485056
* Changes the type signature to use an `object` to represent the Resolver's arguments instead of a TypeScript function signature and moves them to the `$context.arguments` variable. This aligns `functionless` 1:1 with Appsync's VTL environment (a tenet we are adopting for the whole project) and also aligns with existing GraphQL tooling.

## Previous Developer Experience
Before, we required the function signature be explicitly defined. This was both good and bad. Good: use a TypeScript function signature to describe the resolver, which "feels native". Bad: there is a redundant declaration of the argument, `id`, which left room for user-error, and it did not align well with exiting tooling for GraphQL resolvers and code generators, see: #24.
```ts
new AppsyncFunction<(id: string) => Person>(($context, id) => {
  return table.get({
    key: {
      id: { S: id }
    }
  });
})
```

## New Developer Experience
After this change, there are two ways to define an `AppsyncResolver`:

1. infer `TArgs` and `TResult` from the function expression:
```ts
new AppsyncResolver(($context: AppsyncContext<{id: string}>) => {
  return table.get({
    key: {
      id: { S: $context.arguments.id }
    }
  });
})
```

2. explicitly define the type and then omit it from the `$context` argument declaration:
```ts
new AppsyncResolver<{id: string>, Person>(($context) => {
  return table.get({
    key: {
      id: { S: $context.arguments.id }
    }
  });
})
```

### `TSource`

In GraphQL, there is the concept of a "source", which represents the parent object containing the field being resolved. In the previous two examples, `TSource` is omitted from the `AppsyncContext` and `AppsyncResolver` type signatures. When it is omitted, its type defaults to `undefined`, meaning no parent - the most common case for root-level fields.

To define `TSource`, you can either add it to the `AppsyncContext` or `AppsyncResolver` type signatures, depending on the developer's preference.

```ts
// option 1 - explicit types in AppsyncContext
new AppsyncResolver(($context: AppsyncContext<{id: string}, TSource>) => {});

// option 2 - explicit types in AppsyncResolver
new AppsyncResolver<{id: string>, Person, TSource>(($context) => {});
```

I personally prefer option 1 - specify it in `AppsyncContext` 

BREAKING CHANGE: AppsyncFunction is renamed to AppsyncResolver and the arguments are now defined as an object instead of as a function signature

