### PR TITLE
fix: improve error message when reference is used in reflect

### DIFF
--- a/src/compile.ts
+++ b/src/compile.ts
@@ -79,7 +79,6 @@ export function compile(
           const exprType = checker.getTypeAtLocation(node.expression);
           const exprDecl = exprType.symbol?.declarations?.[0];
           if (exprDecl && ts.isFunctionDeclaration(exprDecl)) {
-            console.log(exprDecl.name?.text);
             if (exprDecl.name?.text === "reflect") {
               return true;
             }

--- a/src/compile.ts
+++ b/src/compile.ts
@@ -60,7 +60,9 @@ export function compile(
         } else if (isReflectFunction(node)) {
           const func = node.arguments[0];
           if (ts.isIdentifier(func)) {
-            throw new Error("Reflect does not support function references");
+            throw new Error(
+              `Reflect does not support function references: ${func.text}`
+            );
           }
           return toFunction("FunctionDecl", func);
         }


### PR DESCRIPTION
Previous error message: `cannot parse declaration-only function: ${text}`
New error message: `Reflect does not support function references: ${text}`