### PR TITLE
fix: improve VTL synth to support if-statements after a service call and inline dereferencing of service call

### DIFF
--- a/src/appsync.ts
+++ b/src/appsync.ts
@@ -50,10 +50,6 @@ export type ResolverFunction<
   Source
 > = ($context: AppsyncContext<Arguments, Source>) => Result;
 
-export interface MaterializedResolverProps extends appsync.ResolverProps {
-  templates: string[];
-}
-
 export interface MaterializedResolver extends appsync.Resolver {
   readonly templates: string[];
 }

--- a/src/expression.ts
+++ b/src/expression.ts
@@ -1,7 +1,7 @@
 import { ParameterDecl } from "./declaration";
 import { AnyFunction, AnyLambda } from "./function";
 import { BaseNode, isNode, setParent, typeGuard } from "./node";
-import { BlockStmt, IfStmt, isIfStmt } from "./statement";
+import { BlockStmt } from "./statement";
 import { AnyTable } from "./table";
 
 /**
@@ -14,7 +14,6 @@ export type Expr =
   | CallExpr
   | ConditionExpr
   | FunctionExpr
-  | IfStmt
   | ElementAccessExpr
   | Identifier
   | NullLiteralExpr
@@ -38,7 +37,6 @@ export function isExpr(a: any) {
       isCallExpr(a) ||
       isConditionExpr(a) ||
       isFunctionExpr(a) ||
-      isIfStmt(a) ||
       isElementAccessExpr(a) ||
       isIdentifier(a) ||
       isNullLiteralExpr(a) ||

--- a/src/statement.ts
+++ b/src/statement.ts
@@ -11,6 +11,7 @@ export type Stmt =
   | ExprStmt
   | ForInStmt
   | ForOfStmt
+  | IfStmt
   | ReturnStmt
   | VariableStmt;
 
@@ -21,6 +22,7 @@ export function isStmt(a: any): a is Stmt {
       isExprStmt(a) ||
       isForInStmt(a) ||
       isForOfStmt(a) ||
+      isIfStmt(a) ||
       isReturn(a) ||
       isVariableStmt(a))
   );

--- a/src/vtl.ts
+++ b/src/vtl.ts
@@ -1,15 +1,18 @@
-import { CallExpr, Expr } from "./expression";
+import { CallExpr, Expr, FunctionExpr } from "./expression";
 import { findFunction, isInTopLevelScope, lookupIdentifier } from "./util";
 import { assertNever } from "./assert";
 import { FunctionlessNode } from "./node";
 import { Stmt } from "./statement";
-import { FunctionExpr } from ".";
 
 // https://velocity.apache.org/engine/devel/user-guide.html#conditionals
 // https://cwiki.apache.org/confluence/display/VELOCITY/CheckingForNull
 // https://velocity.apache.org/engine/devel/user-guide.html#set
 
 export class VTL {
+  public static readonly CircuitBreaker = `#if($context.stash.return__flag)
+  #return($context.stash.return__val)
+#end`;
+
   private readonly statements: string[] = [];
 
   private varIt = 0;
@@ -25,28 +28,6 @@ export class VTL {
   public add(...statements: string[]) {
     this.statements.push(...statements);
   }
-
-  /**
-   * Declare a new variable.
-   *
-   * @param expr - optional value to initialize the value to
-   * @returns the variable reference, e.g. $v1
-   */
-  // public var(expr?: Expr | string): string;
-  // public var(id?: string): string;
-  // public var(id: string, expr: Expr): string;
-  // public var(a?: string | Expr, b?: Expr): string {
-  //   if (a === undefined && b === undefined) {
-  //     return this.newLocalVarName();
-  //   } else if (typeof a === "string") {
-
-  //     this.set(a, b);
-  //     return a;
-  //   }
-  //   const varName = this.newLocalVarName();
-  //   this.set(varName, a as Expr);
-  //   return varName;
-  // }
 
   private newLocalVarName() {
     return `$v${(this.varIt += 1)}`;

--- a/test/function.test.ts
+++ b/test/function.test.ts
@@ -1,25 +1,50 @@
+import { App, aws_lambda, Stack } from "aws-cdk-lib";
 import "jest";
 import { AppsyncContext, reflect } from "../src";
 import { Function } from "../src";
-import { returnExpr, testCase } from "./util";
+import { VTL } from "../src/vtl";
+import { testCase } from "./util";
 
 interface Item {
   id: string;
   name: number;
 }
 
-const fn1 = new Function<(arg: string) => Item>(null as any);
-const fn2 = new Function<(arg: string, optional?: string) => Item>(null as any);
+const app = new App({ autoSynth: false });
+const stack = new Stack(app, "stack");
+
+const lambda = new aws_lambda.Function(stack, "F", {
+  code: aws_lambda.Code.fromInline(
+    "exports.handler = function() { return null; }"
+  ),
+  handler: "index.handler",
+  runtime: aws_lambda.Runtime.NODEJS_14_X,
+});
+
+const fn1 = new Function<(arg: string) => Item>(lambda);
+const fn2 = new Function<(arg: string, optional?: string) => Item>(lambda);
 
 test("call function", () =>
   testCase(
     reflect((context: AppsyncContext<{ arg: string }>) => {
       return fn1(context.arguments.arg);
     }),
-    `#set($v1 = {})
+    // pipeline's request mapping template
+    "{}",
+    // function's request mapping template
+    `${VTL.CircuitBreaker}
+#set($v1 = {})
 $util.qr($v1.put('arg', $context.arguments.arg))
 #set($v2 = {\"version\": \"2018-05-29\", \"operation\": \"Invoke\", \"payload\": $v1})
-${returnExpr("$util.toJson($v2)")}`
+$util.toJson($v2)`,
+    // function's response mapping template
+    `#set( $context.stash.return__flag = true )
+#set( $context.stash.return__val = $context.result )
+{}`,
+    // response mapping template
+    `#if($context.stash.return__flag)
+  #return($context.stash.return__val)
+#end`
   ));
 
 test("call function omitting optional arg", () =>
@@ -27,11 +52,23 @@ test("call function omitting optional arg", () =>
     reflect((context: AppsyncContext<{ arg: string }>) => {
       return fn2(context.arguments.arg);
     }),
-    `#set($v1 = {})
+    // pipeline's request mapping template
+    "{}",
+    // function's request mapping template
+    `${VTL.CircuitBreaker}
+#set($v1 = {})
 $util.qr($v1.put('arg', $context.arguments.arg))
 $util.qr($v1.put('optional', $null))
 #set($v2 = {\"version\": \"2018-05-29\", \"operation\": \"Invoke\", \"payload\": $v1})
-${returnExpr("$util.toJson($v2)")}`
+$util.toJson($v2)`,
+    // function's response mapping template
+    `#set( $context.stash.return__flag = true )
+#set( $context.stash.return__val = $context.result )
+{}`,
+    // response mapping template
+    `#if($context.stash.return__flag)
+  #return($context.stash.return__val)
+#end`
   ));
 
 test("call function including optional arg", () =>
@@ -39,9 +76,21 @@ test("call function including optional arg", () =>
     reflect((context: AppsyncContext<{ arg: string }>) => {
       return fn2(context.arguments.arg, "hello");
     }),
-    `#set($v1 = {})
+    // pipeline's request mapping template
+    "{}",
+    // function's request mapping template
+    `${VTL.CircuitBreaker}
+#set($v1 = {})
 $util.qr($v1.put('arg', $context.arguments.arg))
 $util.qr($v1.put('optional', 'hello'))
 #set($v2 = {\"version\": \"2018-05-29\", \"operation\": \"Invoke\", \"payload\": $v1})
-${returnExpr("$util.toJson($v2)")}`
+$util.toJson($v2)`,
+    // function's response mapping template
+    `#set( $context.stash.return__flag = true )
+#set( $context.stash.return__val = $context.result )
+{}`,
+    // response mapping template
+    `#if($context.stash.return__flag)
+  #return($context.stash.return__val)
+#end`
   ));

--- a/test/table.test.ts
+++ b/test/table.test.ts
@@ -1,14 +1,26 @@
+import { App, aws_dynamodb, Stack } from "aws-cdk-lib";
 import "jest";
 import { $util, AppsyncContext, reflect } from "../src";
 import { Table } from "../src";
-import { returnExpr, testCase } from "./util";
+import { VTL } from "../src/vtl";
+import { testCase } from "./util";
 
 interface Item {
   id: string;
   name: number;
 }
 
-const table = new Table<Item, "id">(null as any);
+const app = new App({ autoSynth: false });
+const stack = new Stack(app, "stack");
+
+const table = new Table<Item, "id">(
+  new aws_dynamodb.Table(stack, "Table", {
+    partitionKey: {
+      name: "id",
+      type: aws_dynamodb.AttributeType.STRING,
+    },
+  })
+);
 
 test("get item", () =>
   testCase(
@@ -21,7 +33,11 @@ test("get item", () =>
         },
       });
     }),
-    `#set($v1 = {})
+    // pipeline's request mapping template
+    "{}",
+    // function's request mapping template
+    `${VTL.CircuitBreaker}
+#set($v1 = {})
 #set($v2 = {})
 #set($v3 = {})
 $util.qr($v3.put('S', $context.arguments.id))
@@ -32,7 +48,15 @@ $util.qr($v4.put('key', $v1.get('key')))
 #if($v1.containsKey('consistentRead'))
 $util.qr($v4.put('consistentRead', $v1.get('consistentRead')))
 #end
-${returnExpr("$util.toJson($v4)")}`
+$util.toJson($v4)`,
+    // function's response mapping template
+    `#set( $context.stash.return__flag = true )
+#set( $context.stash.return__val = $context.result )
+{}`,
+    // response mapping template
+    `#if($context.stash.return__flag)
+  #return($context.stash.return__val)
+#end`
   ));
 
 test("get item and set consistentRead:true", () =>
@@ -47,7 +71,11 @@ test("get item and set consistentRead:true", () =>
         consistentRead: true,
       });
     }),
-    `#set($v1 = {})
+    // pipeline's request mapping template
+    "{}",
+    // function's request mapping template
+    `${VTL.CircuitBreaker}
+#set($v1 = {})
 #set($v2 = {})
 #set($v3 = {})
 $util.qr($v3.put('S', $context.arguments.id))
@@ -59,7 +87,15 @@ $util.qr($v4.put('key', $v1.get('key')))
 #if($v1.containsKey('consistentRead'))
 $util.qr($v4.put('consistentRead', $v1.get('consistentRead')))
 #end
-${returnExpr("$util.toJson($v4)")}`
+$util.toJson($v4)`,
+    // function's response mapping template
+    `#set( $context.stash.return__flag = true )
+#set( $context.stash.return__val = $context.result )
+{}`,
+    // pipeline's response mapping template
+    `#if($context.stash.return__flag)
+  #return($context.stash.return__val)
+#end`
   ));
 
 test("put item", () =>
@@ -93,7 +129,11 @@ test("put item", () =>
         });
       }
     ),
-    `#set($v1 = {})
+    // pipeline's request mapping template
+    "{}",
+    // function's request mapping template
+    `${VTL.CircuitBreaker}
+#set($v1 = {})
 #set($v2 = {})
 #set($v3 = {})
 $util.qr($v3.put('S', $context.arguments.id))
@@ -124,9 +164,15 @@ $util.qr($v10.put('condition', $v1.get('condition')))
 #if($v1.containsKey('_version'))
 $util.qr($v10.put('_version', $v1.get('_version')))
 #end
-#set($context.stash.return__val = $util.toJson($v10))
-#set($context.stash.return__flag = true)
-#return($context.stash.return__val)`
+$util.toJson($v10)`,
+    // function's response mapping template
+    `#set( $context.stash.return__flag = true )
+#set( $context.stash.return__val = $context.result )
+{}`,
+    // pipeline's response mapping template
+    `#if($context.stash.return__flag)
+  #return($context.stash.return__val)
+#end`
   ));
 
 test("update item", () =>
@@ -146,7 +192,11 @@ test("update item", () =>
         },
       });
     }),
-    `#set($v1 = {})
+    // pipeline's request mapping template
+    "{}",
+    // function's request mapping template
+    `${VTL.CircuitBreaker}
+#set($v1 = {})
 #set($v2 = {})
 #set($v3 = {})
 $util.qr($v3.put('S', $context.arguments.id))
@@ -167,7 +217,15 @@ $util.qr($v6.put('condition', $v1.get('condition')))
 #if($v1.containsKey('_version'))
 $util.qr($v6.put('_version', $v1.get('_version')))
 #end
-${returnExpr("$util.toJson($v6)")}`
+$util.toJson($v6)`,
+    // function's response mapping template
+    `#set( $context.stash.return__flag = true )
+#set( $context.stash.return__val = $context.result )
+{}`,
+    // pipeline's response mapping template
+    `#if($context.stash.return__flag)
+  #return($context.stash.return__val)
+#end`
   ));
 
 test("delete item", () =>
@@ -187,7 +245,11 @@ test("delete item", () =>
         },
       });
     }),
-    `#set($v1 = {})
+    // pipeline's request mapping template
+    "{}",
+    // function's request mapping template
+    `${VTL.CircuitBreaker}
+#set($v1 = {})
 #set($v2 = {})
 #set($v3 = {})
 $util.qr($v3.put('S', $context.arguments.id))
@@ -207,7 +269,15 @@ $util.qr($v6.put('condition', $v1.get('condition')))
 #if($v1.containsKey('_version'))
 $util.qr($v6.put('_version', $v1.get('_version')))
 #end
-${returnExpr("$util.toJson($v6)")}`
+$util.toJson($v6)`,
+    // function's response mapping template
+    `#set( $context.stash.return__flag = true )
+#set( $context.stash.return__val = $context.result )
+{}`,
+    // pipeline's response mapping template
+    `#if($context.stash.return__flag)
+  #return($context.stash.return__val)
+#end`
   ));
 
 test("query", () =>
@@ -226,7 +296,11 @@ test("query", () =>
         },
       }).items;
     }),
-    `#set($v1 = {})
+    // pipeline's request mapping template
+    "{}",
+    // function's request mapping template
+    `${VTL.CircuitBreaker}
+#set($v1 = {})
 #set($v2 = {})
 $util.qr($v2.put('expression', 'id = :id and #name = :val'))
 #set($v3 = {})
@@ -258,7 +332,13 @@ $util.qr($v5.put('consistentRead', $v1.get('consistentRead')))
 #if($v1.containsKey('select'))
 $util.qr($v5.put('select', $v1.get('select')))
 #end
-#set($context.stash.return__val = $util.toJson($v5).items)
-#set($context.stash.return__flag = true)
-#return($context.stash.return__val)`
+$util.toJson($v5)`,
+    // function's response mapping template
+    `#set( $context.stash.return__flag = true )
+#set( $context.stash.return__val = $context.result.items )
+{}`,
+    // pipeline's response mapping template
+    `#if($context.stash.return__flag)
+  #return($context.stash.return__val)
+#end`
   ));

--- a/test/table.test.ts
+++ b/test/table.test.ts
@@ -3,7 +3,7 @@ import "jest";
 import { $util, AppsyncContext, reflect } from "../src";
 import { Table } from "../src";
 import { VTL } from "../src/vtl";
-import { testCase } from "./util";
+import { appsyncTestCase } from "./util";
 
 interface Item {
   id: string;
@@ -23,7 +23,7 @@ const table = new Table<Item, "id">(
 );
 
 test("get item", () =>
-  testCase(
+  appsyncTestCase(
     reflect((context: AppsyncContext<{ id: string }>): Item | undefined => {
       return table.getItem({
         key: {
@@ -60,7 +60,7 @@ $util.toJson($v4)`,
   ));
 
 test("get item and set consistentRead:true", () =>
-  testCase(
+  appsyncTestCase(
     reflect((context: AppsyncContext<{ id: string }>): Item | undefined => {
       return table.getItem({
         key: {
@@ -99,7 +99,7 @@ $util.toJson($v4)`,
   ));
 
 test("put item", () =>
-  testCase(
+  appsyncTestCase(
     reflect(
       (
         context: AppsyncContext<{ id: string; name: number }>
@@ -176,7 +176,7 @@ $util.toJson($v10)`,
   ));
 
 test("update item", () =>
-  testCase(
+  appsyncTestCase(
     reflect((context: AppsyncContext<{ id: string }>): Item | undefined => {
       return table.updateItem({
         key: {
@@ -229,7 +229,7 @@ $util.toJson($v6)`,
   ));
 
 test("delete item", () =>
-  testCase(
+  appsyncTestCase(
     reflect((context: AppsyncContext<{ id: string }>): Item | undefined => {
       return table.deleteItem({
         key: {
@@ -281,7 +281,7 @@ $util.toJson($v6)`,
   ));
 
 test("query", () =>
-  testCase(
+  appsyncTestCase(
     reflect((context: AppsyncContext<{ id: string; sort: number }>): Item[] => {
       return table.query({
         query: {

--- a/test/util.ts
+++ b/test/util.ts
@@ -11,7 +11,7 @@ export function returnExpr(varName: string) {
 #return($context.stash.return__val)`;
 }
 
-export function testCase(decl: FunctionDecl, ...expected: string[]) {
+export function appsyncTestCase(decl: FunctionDecl, ...expected: string[]) {
   const app = new App({ autoSynth: false });
   const stack = new Stack(app, "stack");
 

--- a/test/util.ts
+++ b/test/util.ts
@@ -1,5 +1,8 @@
-import { FunctionDecl } from "../src";
-import { VTL } from "../src/vtl";
+import { App, Stack } from "aws-cdk-lib";
+import { AppsyncResolver, FunctionDecl } from "../src";
+
+import * as appsync from "@aws-cdk/aws-appsync-alpha";
+import path from "path";
 
 // generates boilerplate for the circuit-breaker logic for implementing early return
 export function returnExpr(varName: string) {
@@ -8,9 +11,30 @@ export function returnExpr(varName: string) {
 #return($context.stash.return__val)`;
 }
 
-export function testCase(decl: FunctionDecl, expected: string) {
-  const vtl = new VTL();
-  vtl.eval(decl.body);
-  const actual = vtl.toVTL();
+export function testCase(decl: FunctionDecl, ...expected: string[]) {
+  const app = new App({ autoSynth: false });
+  const stack = new Stack(app, "stack");
+
+  const schema = new appsync.Schema({
+    filePath: path.join(__dirname, "..", "test-app", "schema.gql"),
+  });
+
+  const api = new appsync.GraphqlApi(stack, "Api", {
+    name: "demo",
+    schema,
+    authorizationConfig: {
+      defaultAuthorization: {
+        authorizationType: appsync.AuthorizationType.IAM,
+      },
+    },
+    xrayEnabled: true,
+  });
+
+  const appsyncFunction = new AppsyncResolver(decl as any);
+  const actual = appsyncFunction.addResolver(api, {
+    typeName: "Query",
+    fieldName: "getPerson",
+  }).templates;
+
   expect(actual).toEqual(expected);
 }

--- a/test/vtl.test.ts
+++ b/test/vtl.test.ts
@@ -2,7 +2,7 @@ import "jest";
 import { $util } from "../lib";
 import { AppsyncContext } from "../src";
 import { reflect } from "../src/reflect";
-import { returnExpr, testCase } from "./util";
+import { returnExpr, appsyncTestCase } from "./util";
 
 const payload = `{
   "version": "2018-05-29",
@@ -10,7 +10,7 @@ const payload = `{
 }`;
 
 test("empty function returning an argument", () => {
-  testCase(
+  appsyncTestCase(
     reflect((context: AppsyncContext<{ a: string }>) => {
       return context.arguments.a;
     }),
@@ -20,7 +20,7 @@ test("empty function returning an argument", () => {
 });
 
 test("return literal object with values", () => {
-  testCase(
+  appsyncTestCase(
     reflect(
       (context: AppsyncContext<{ arg: string; obj: Record<string, any> }>) => {
         const arg = context.arguments.arg;
@@ -58,7 +58,7 @@ $util.qr($v1.putAll($context.stash.obj))
 });
 
 test("call function and return its value", () => {
-  testCase(
+  appsyncTestCase(
     reflect(() => {
       return $util.autoId();
     }),
@@ -68,7 +68,7 @@ test("call function and return its value", () => {
 });
 
 test("call function, assign to variable and return variable reference", () => {
-  testCase(
+  appsyncTestCase(
     reflect(() => {
       const id = $util.autoId();
       return id;
@@ -80,7 +80,7 @@ test("call function, assign to variable and return variable reference", () => {
 });
 
 test("return in-line spread object", () => {
-  testCase(
+  appsyncTestCase(
     reflect((context: AppsyncContext<{ obj: { key: string } }>) => {
       return {
         id: $util.autoId(),
@@ -96,7 +96,7 @@ $util.qr($v1.putAll($context.arguments.obj))
 });
 
 test("return in-line list literal", () => {
-  testCase(
+  appsyncTestCase(
     reflect((context: AppsyncContext<{ a: string; b: string }>) => {
       return [context.arguments.a, context.arguments.b];
     }),
@@ -106,7 +106,7 @@ test("return in-line list literal", () => {
 });
 
 test("return list literal variable", () => {
-  testCase(
+  appsyncTestCase(
     reflect((context: AppsyncContext<{ a: string; b: string }>) => {
       const list = [context.arguments.a, context.arguments.b];
       return list;
@@ -118,7 +118,7 @@ test("return list literal variable", () => {
 });
 
 test("return list element", () => {
-  testCase(
+  appsyncTestCase(
     reflect((context: AppsyncContext<{ a: string; b: string }>) => {
       const list = [context.arguments.a, context.arguments.b];
       return list[0];
@@ -130,7 +130,7 @@ test("return list element", () => {
 });
 
 test("push element to array is renamed to add", () => {
-  testCase(
+  appsyncTestCase(
     reflect((context: AppsyncContext<{ list: string[] }>) => {
       context.arguments.list.push("hello");
       return context.arguments.list;
@@ -158,7 +158,7 @@ test("push element to array is renamed to add", () => {
 // });
 
 test("if statement", () => {
-  testCase(
+  appsyncTestCase(
     reflect((context: AppsyncContext<{ list: string[] }>) => {
       if (context.arguments.list.length > 0) {
         return true;
@@ -176,7 +176,7 @@ ${returnExpr("false")}
 });
 
 test("return conditional expression", () => {
-  testCase(
+  appsyncTestCase(
     reflect((context: AppsyncContext<{ list: string[] }>) => {
       return context.arguments.list.length > 0 ? true : false;
     }),
@@ -191,7 +191,7 @@ test("return conditional expression", () => {
 });
 
 test("property assignment of conditional expression", () => {
-  testCase(
+  appsyncTestCase(
     reflect((context: AppsyncContext<{ list: string[] }>) => {
       return {
         prop: context.arguments.list.length > 0 ? true : false,
@@ -210,7 +210,7 @@ $util.qr($v1.put('prop', $v2))
 });
 
 test("for-of loop", () => {
-  testCase(
+  appsyncTestCase(
     reflect((context: AppsyncContext<{ list: string[] }>) => {
       const newList = [];
       for (const item of context.arguments.list) {
@@ -228,7 +228,7 @@ $util.qr($context.stash.newList.add($item))
 });
 
 test("break from for-loop", () => {
-  testCase(
+  appsyncTestCase(
     reflect((context: AppsyncContext<{ list: string[] }>) => {
       const newList = [];
       for (const item of context.arguments.list) {
@@ -252,7 +252,7 @@ $util.qr($context.stash.newList.add($item))
 });
 
 test("local variable inside for-of loop is declared as a local variable", () => {
-  testCase(
+  appsyncTestCase(
     reflect((context: AppsyncContext<{ list: string[] }>) => {
       const newList = [];
       for (const item of context.arguments.list) {
@@ -272,7 +272,7 @@ $util.qr($context.stash.newList.add($i))
 });
 
 test("for-in loop and element access", () => {
-  testCase(
+  appsyncTestCase(
     reflect((context: AppsyncContext<{ record: Record<string, any> }>) => {
       const newList = [];
       for (const key in context.arguments.record) {
@@ -290,7 +290,7 @@ $util.qr($context.stash.newList.add($context.arguments.record[$key]))
 });
 
 test("template expression", () => {
-  testCase(
+  appsyncTestCase(
     reflect((context: AppsyncContext<{ a: string }>) => {
       const local = context.arguments.a;
       return `head ${context.arguments.a} ${local}${context.arguments.a}`;
@@ -302,7 +302,7 @@ test("template expression", () => {
 });
 
 test("conditional expression in template expression", () => {
-  testCase(
+  appsyncTestCase(
     reflect((context: AppsyncContext<{ a: string }>) => {
       return `head ${
         context.arguments.a === "hello" ? "world" : context.arguments.a
@@ -319,7 +319,7 @@ test("conditional expression in template expression", () => {
 });
 
 test("map over list", () =>
-  testCase(
+  appsyncTestCase(
     reflect((context: AppsyncContext<{ list: string[] }>) => {
       return context.arguments.list.map((item) => {
         return `hello ${item}`;
@@ -335,7 +335,7 @@ $util.qr($v1.add($v2))
   ));
 
 test("map over list with in-line return", () =>
-  testCase(
+  appsyncTestCase(
     reflect((context: AppsyncContext<{ list: string[] }>) => {
       return context.arguments.list.map((item) => `hello ${item}`);
     }),
@@ -349,7 +349,7 @@ $util.qr($v1.add($v2))
   ));
 
 test("chain map over list", () =>
-  testCase(
+  appsyncTestCase(
     reflect((context: AppsyncContext<{ list: string[] }>) => {
       return context.arguments.list
         .map((item) => `hello ${item}`)
@@ -366,7 +366,7 @@ $util.qr($v1.add($v2))
   ));
 
 test("chain map over list multiple array", () =>
-  testCase(
+  appsyncTestCase(
     reflect((context: AppsyncContext<{ list: string[] }>) => {
       return context.arguments.list
         .map((item, _i, _arr) => `hello ${item}`)
@@ -391,7 +391,7 @@ $util.qr($v1.add($v4))
   ));
 
 test("chain map over list complex", () =>
-  testCase(
+  appsyncTestCase(
     reflect((context: AppsyncContext<{ list: string[] }>) => {
       return context.arguments.list
         .map((item, i, arr) => {
@@ -415,7 +415,7 @@ $util.qr($v1.add($v2))
   ));
 
 test("forEach over list", () =>
-  testCase(
+  appsyncTestCase(
     reflect((context: AppsyncContext<{ list: string[] }>) => {
       return context.arguments.list.forEach((item) => {
         $util.error(item);
@@ -429,7 +429,7 @@ $util.qr($util.error($item))
   ));
 
 test("reduce over list with initial value", () =>
-  testCase(
+  appsyncTestCase(
     reflect((context: AppsyncContext<{ list: string[] }>) => {
       return context.arguments.list.reduce((newList: string[], item) => {
         return [...newList, item];
@@ -449,7 +449,7 @@ $util.qr($v3.add($item))
   ));
 
 test("reduce over list without initial value", () =>
-  testCase(
+  appsyncTestCase(
     reflect((context: AppsyncContext<{ list: string[] }>) => {
       return context.arguments.list.reduce((str: string, item) => {
         return `${str}${item}`;
@@ -472,7 +472,7 @@ $util.error('Reduce of empty array with no initial value')
   ));
 
 test("map and reduce over list with initial value", () =>
-  testCase(
+  appsyncTestCase(
     reflect((context: AppsyncContext<{ list: string[] }>) => {
       return context.arguments.list
         .map((item) => `hello ${item}`)
@@ -495,7 +495,7 @@ $util.qr($v3.add($item))
   ));
 
 test("map and reduce with array over list with initial value", () =>
-  testCase(
+  appsyncTestCase(
     reflect((context: AppsyncContext<{ list: string[] }>) => {
       return context.arguments.list
         .map((item) => `hello ${item}`)
@@ -524,7 +524,7 @@ $util.qr($v5.add($item))
   ));
 
 test("map and reduce and map and reduce over list with initial value", () =>
-  testCase(
+  appsyncTestCase(
     reflect((context: AppsyncContext<{ list: string[] }>) => {
       return context.arguments.list
         .map((item) => `hello ${item}`)


### PR DESCRIPTION
There were some bugs in how we synthed VTL:

1. if-statements occurring after the last service call were ignored.
```ts
const result = serviceCall()
// below did not result in VTL
if (result.cond) {
  return result.a;
} else {
  return result.b;
}
```
2. in-lined PropAccessExpr on a service call was ignored and broke the request mapping template
```ts
return serviceCall().prop
```

The request mapping template would mistakenly place the `.prop` reference on the request:
```
$util.toJson($v1.prop)
```

Now, the response mapping template contains that reference:
```
#set($context.stash.return__val = $context.result.prop)
```

3. the NoneDataSource required that the request mapping template was an object with `version` and `payload` properties.
```
{
  "version": "2018-05-29",
  "payload": null
}
```