### PR TITLE
fix: update lambda function to accept json payload

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ The `Function` wrapper annotates an `aws_lambda.Function` with a TypeScript func
 import { aws_lambda } from "aws-cdk-lib";
 import { Function } from "functionless";
 
-const myFunc = new Function<string, string>(
+const myFunc = new Function<{ name: string }, string>(
   new aws_lambda.Function(this, "MyFunc", {
     ..
   })
@@ -153,11 +153,11 @@ Within an [AppsyncResolver](#AppsyncResolver), you can use the `myFunc` referenc
 
 ```ts
 new AppsyncResolver(() => {
-  return myFunc("my name");
+  return myFunc({ name: "my name" });
 });
 ```
 
-The arguments are converted into keys on an object that is passed to the Lambda Function.
+The first argument is passed to the Lambda Function.
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ The `Function` wrapper annotates an `aws_lambda.Function` with a TypeScript func
 import { aws_lambda } from "aws-cdk-lib";
 import { Function } from "functionless";
 
-const myFunc = new Function<(name: string) => string>(
+const myFunc = new Function<string, string>(
   new aws_lambda.Function(this, "MyFunc", {
     ..
   })

--- a/src/declaration.ts
+++ b/src/declaration.ts
@@ -1,6 +1,6 @@
-import { AnyFunction } from "./function";
 import { BaseNode, isNode, setParent, typeGuard } from "./node";
 import { BlockStmt } from "./statement";
+import { AnyFunction } from "./util";
 
 export type Decl = FunctionDecl | ParameterDecl;
 

--- a/src/expression.ts
+++ b/src/expression.ts
@@ -1,8 +1,9 @@
 import { ParameterDecl } from "./declaration";
-import { AnyFunction, AnyLambda } from "./function";
+import { AnyLambda } from "./function";
 import { BaseNode, isNode, setParent, typeGuard } from "./node";
 import { BlockStmt } from "./statement";
 import { AnyTable } from "./table";
+import { AnyFunction } from "./util";
 
 /**
  * An {@link Expr} (Expression) is a Node that will be interpreted to a value.

--- a/src/reflect.ts
+++ b/src/reflect.ts
@@ -1,5 +1,5 @@
 import { FunctionDecl } from "./declaration";
-import { AnyFunction } from "./function";
+import { AnyFunction } from "./util";
 
 /**
  * A macro (compile-time) function that converts an ArrowFunction or FunctionExpression to a {@link FunctionDecl}.

--- a/src/table.ts
+++ b/src/table.ts
@@ -68,7 +68,7 @@ export class Table<
   PartitionKey extends keyof Item,
   RangeKey extends keyof Item | undefined = undefined
 > {
-  readonly kind: "Table" = "Table";
+  readonly kind = "Table" as const;
 
   constructor(readonly resource: aws_dynamodb.ITable) {}
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,7 +1,10 @@
 import { CallExpr, Identifier } from "./expression";
-import { AnyFunction, AnyLambda } from "./function";
+import { AnyLambda } from "./function";
 import { FunctionlessNode } from "./node";
 import { AnyTable } from "./table";
+import { VTL } from "./vtl";
+
+export type AnyFunction = (...args: any[]) => any;
 
 export function lookupIdentifier(id: Identifier) {
   return lookup(id.parent);
@@ -84,7 +87,9 @@ export function isInTopLevelScope(expr: FunctionlessNode): boolean {
   }
 }
 
-export function findFunction(call: CallExpr): AnyFunction | undefined {
+export function findFunction(
+  call: CallExpr
+): ((call: CallExpr, vtl: VTL) => string) | undefined {
   return find(call.expr);
 
   function find(expr: FunctionlessNode): any {

--- a/test-app/src/people-db.ts
+++ b/test-app/src/people-db.ts
@@ -37,7 +37,7 @@ export class PeopleDatabase extends Construct {
       })
     );
 
-    this.computeScore = new Function<(person: Person) => number>(
+    this.computeScore = new Function<Person, number>(
       new aws_lambda.Function(this, "ComputeScore", {
         code: aws_lambda.Code.fromInline(
           "exports.handle = async function() {return 1;}"

--- a/test/vtl.test.ts
+++ b/test/vtl.test.ts
@@ -1,5 +1,5 @@
 import "jest";
-import { $util } from "../lib";
+import { $util } from "../src";
 import { AppsyncContext } from "../src";
 import { reflect } from "../src/reflect";
 import { returnExpr, appsyncTestCase } from "./util";


### PR DESCRIPTION
Fixes #42

Previously, Lambda Functions were defined with a type parameter that represented the function signature. Arguments were turned into objects using their names.

```ts
const myFunction = new Function<(arg1: string, arg2: number) => string>(...);

myFunction("some string", 10);

// actual json into the lambda
{
   arg1: "some string:",
   arg2: 10
}
```

This PR updates the function to accept a single Payload argument, matching the public lambda contract that accepts any single JSON input as a parameter.

```ts
const myFunction = new Function<{ arg1: string, arg2: number }, string>(...)

myFunction({ arg1: "some string", arg2: 10 });
```

The payload passed to the lambda function is the same as the above example.

The new representation allows for bare strings, numbers, and nulls.

```ts
const myFunction = new Function<string, string>(...)

myFunction(some string"");
```

This example is passed to the lambda functions as expected, as a bare string.

----

BREAKING CHANGE: Function signature changed from argument list to one or zero arguments for payload as json. Function type parameter is now a payload type and a return type. Function return type defaults to void.