### PR TITLE
feat: compile returns error node instead of throwing

### DIFF
--- a/src/appsync.ts
+++ b/src/appsync.ts
@@ -9,9 +9,10 @@ import {
   ToAttributeMap,
   ToAttributeValue,
 } from "typesafe-dynamodb/lib/attribute-value";
-import { FunctionDecl } from "./declaration";
+import { FunctionDecl, isFunctionDecl } from "./declaration";
 import { Literal } from "./literal";
 import { Construct } from "constructs";
+import { isErr } from "./error";
 
 /**
  * The shape of the AWS Appsync `$context` variable.
@@ -122,7 +123,13 @@ export class AppsyncResolver<
   >;
 
   constructor(fn: ResolverFunction<Arguments, Result, Source>) {
-    this.decl = fn as unknown as FunctionDecl;
+    if (isFunctionDecl(fn)) {
+      this.decl = fn;
+    } else if (isErr(fn)) {
+      throw fn.error;
+    } else {
+      throw Error("Unknown compiler error.");
+    }
   }
 
   /**

--- a/src/assert.ts
+++ b/src/assert.ts
@@ -1,3 +1,15 @@
+import { FunctionlessNode } from "./node";
+
 export function assertNever(value: never): never {
   throw new Error(`reached unreachable branch with value: ${value}`);
+}
+
+export function assertNodeKind<T extends FunctionlessNode>(
+  node: FunctionlessNode,
+  kind: T["kind"]
+): T {
+  if (node.kind !== kind) {
+    throw Error(`Expected node of type ${kind} and found ${node.kind}`);
+  }
+  return <T>node;
 }

--- a/src/compile.ts
+++ b/src/compile.ts
@@ -1,4 +1,4 @@
-import ts from "typescript";
+import ts, { Statement } from "typescript";
 import { PluginConfig, TransformerExtras } from "ts-patch";
 import { BinaryOp } from "./expression";
 import { AnyTable } from "./table";
@@ -55,10 +55,22 @@ export function compile(
       );
 
       function visitor(node: ts.Node): ts.Node {
-        if (isAppsyncResolver(node)) {
-          return visitAppsyncResolver(node);
-        } else if (isReflectFunction(node)) {
-          return toFunction("FunctionDecl", node.arguments[0]);
+        try {
+          if (isAppsyncResolver(node)) {
+            return visitAppsyncResolver(node);
+          } else if (isReflectFunction(node)) {
+            return toFunction("FunctionDecl", node.arguments[0]);
+          }
+        } catch (err) {
+          const error =
+            err instanceof Error ? err : Error("Unknown compiler error.");
+          return newExpr("Err", [
+            ts.factory.createNewExpression(
+              ts.factory.createIdentifier(error.name),
+              undefined,
+              [ts.factory.createStringLiteral(error.message)]
+            ),
+          ]) as unknown as Statement;
         }
         return ts.visitEachChild(node, visitor, ctx);
       }

--- a/src/error.ts
+++ b/src/error.ts
@@ -1,0 +1,9 @@
+import { BaseNode, typeGuard } from "./node";
+
+export const isErr = typeGuard("Err");
+
+export class Err extends BaseNode<"Err"> {
+  constructor(readonly error: Error) {
+    super("Err");
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 export * from "./appsync";
 export * from "./declaration";
 export * from "./expression";
+export * from "./error";
 export * from "./function";
 export * from "./reflect";
 export * from "./statement";

--- a/src/node.ts
+++ b/src/node.ts
@@ -1,8 +1,9 @@
 import { Decl } from "./declaration";
+import { Err } from "./error";
 import { Expr } from "./expression";
 import { Stmt } from "./statement";
 
-export type FunctionlessNode = Decl | Expr | Stmt;
+export type FunctionlessNode = Decl | Expr | Stmt | Err;
 
 export function isNode(a: any): a is Expr {
   return typeof a?.kind === "string";

--- a/src/reflect.ts
+++ b/src/reflect.ts
@@ -1,4 +1,5 @@
 import { FunctionDecl } from "./declaration";
+import { Err } from "./error";
 import { AnyFunction } from "./util";
 
 /**
@@ -29,4 +30,4 @@ import { AnyFunction } from "./util";
  */
 export declare function reflect<F extends AnyFunction>(
   func: F
-): FunctionDecl<F>;
+): FunctionDecl<F> | Err;

--- a/src/vtl.ts
+++ b/src/vtl.ts
@@ -415,6 +415,8 @@ export class VTL {
         } else {
           return varName;
         }
+      case "Err":
+        throw node.error;
     }
 
     const __exhaustive: never = node;

--- a/test/reflect.test.ts
+++ b/test/reflect.test.ts
@@ -1,0 +1,49 @@
+import { CallExpr, FunctionDecl, reflect, ReturnStmt } from "../src";
+import { assertNodeKind } from "../src/assert";
+
+test("function", () => expect(reflect(() => {}).kind).toEqual("FunctionDecl"));
+
+test("turns a single line function into a return", () => {
+  const fn = assertNodeKind<FunctionDecl>(
+    reflect(() => ""),
+    "FunctionDecl"
+  );
+
+  expect(fn.body.statements[0].kind).toEqual("ReturnStmt");
+});
+
+test("returns a string", () => {
+  const fn = assertNodeKind<FunctionDecl>(
+    reflect(() => ""),
+    "FunctionDecl"
+  );
+  expect(
+    assertNodeKind<ReturnStmt>(fn.body.statements[0], "ReturnStmt").expr.kind
+  ).toEqual("StringLiteralExpr");
+});
+
+// TODO: Support parenthesis
+test("parenthesis", () => {
+  expect(() =>
+    assertNodeKind<FunctionDecl>(
+      reflect(() => {
+        ("");
+      }),
+      "FunctionDecl"
+    )
+  ).toThrow();
+});
+
+// TODO: support any function and parenthesis
+test.skip("any function args", () => {
+  const result = assertNodeKind<FunctionDecl>(
+    reflect(() => {
+      (<any>"").startsWith("");
+    }),
+    "FunctionDecl"
+  );
+
+  const call = assertNodeKind<CallExpr>(result.body.statements[0], "CallExpr");
+
+  expect(Object.keys(call.args)).toHaveLength(1);
+});

--- a/test/util.ts
+++ b/test/util.ts
@@ -3,6 +3,7 @@ import { AppsyncResolver, FunctionDecl } from "../src";
 
 import * as appsync from "@aws-cdk/aws-appsync-alpha";
 import path from "path";
+import { Err, isErr } from "../src/error";
 
 // generates boilerplate for the circuit-breaker logic for implementing early return
 export function returnExpr(varName: string) {
@@ -11,9 +12,16 @@ export function returnExpr(varName: string) {
 #return($context.stash.return__val)`;
 }
 
-export function appsyncTestCase(decl: FunctionDecl, ...expected: string[]) {
+export function appsyncTestCase(
+  decl: FunctionDecl | Err,
+  ...expected: string[]
+) {
   const app = new App({ autoSynth: false });
   const stack = new Stack(app, "stack");
+
+  if (isErr(decl)) {
+    throw decl.error;
+  }
 
   const schema = new appsync.Schema({
     filePath: path.join(__dirname, "..", "test-app", "schema.gql"),


### PR DESCRIPTION
Compile will no longer throw when re-writing nodes in the ts-tranform. Instead a node of type `Err` is returned. Methods whichs expected the new Functionless nodes should check for `Err` when they also check for the new node types (generally `FunctionDecl`). They can throw the error provided to them from the `Err` node or handle the error how they would like.

Closes #11