### PR TITLE
feat: update call expr to have a list of ArgumentExpr. support parenthesis and type casting in compile.

### DIFF
--- a/src/assert.ts
+++ b/src/assert.ts
@@ -5,11 +5,15 @@ export function assertNever(value: never): never {
 }
 
 export function assertNodeKind<T extends FunctionlessNode>(
-  node: FunctionlessNode,
+  node: FunctionlessNode | undefined,
   kind: T["kind"]
 ): T {
-  if (node.kind !== kind) {
-    throw Error(`Expected node of type ${kind} and found ${node.kind}`);
+  if (node?.kind !== kind) {
+    throw Error(
+      `Expected node of type ${kind} and found ${
+        node ? node.kind : "undefined"
+      }`
+    );
   }
   return <T>node;
 }

--- a/src/compile.ts
+++ b/src/compile.ts
@@ -227,19 +227,22 @@ export function compile(
           } else {
             signature = checker.getResolvedSignature(node);
           }
-          if (signature) {
-            return newExpr("CallExpr", [
-              toExpr(node.expression),
-              ts.factory.createObjectLiteralExpression(
-                signature.parameters.map((parameter, i) =>
-                  ts.factory.createPropertyAssignment(
-                    parameter.name,
-                    toExpr(node.arguments[i])
-                  )
-                )
-              ),
-            ]);
-          }
+          return newExpr("CallExpr", [
+            toExpr(node.expression),
+            ts.factory.createArrayLiteralExpression(
+              node.arguments.map((arg, i) =>
+                newExpr("ArgumentExpr", [
+                  toExpr(arg),
+                  // the arguments array may not match the signature or the signature may be unknown
+                  signature?.parameters?.[i]?.name
+                    ? ts.factory.createStringLiteral(
+                        signature?.parameters?.[i]?.name
+                      )
+                    : ts.factory.createIdentifier("undefined"),
+                ])
+              )
+            ),
+          ]);
         } else if (ts.isBlock(node)) {
           return newExpr("BlockStmt", [
             ts.factory.createArrayLiteralExpression(
@@ -414,6 +417,12 @@ export function compile(
           ]);
         } else if (ts.isBreakStatement(node)) {
           return newExpr("BreakStmt", []);
+        } else if (ts.isParenthesizedExpression(node)) {
+          return toExpr(node.expression);
+        } else if (ts.isAsExpression(node)) {
+          return toExpr(node.expression);
+        } else if (ts.isTypeAssertionExpression(node)) {
+          return toExpr(node.expression);
         }
 
         throw new Error(`unhandled node: ${node.getText()}`);

--- a/src/compile.ts
+++ b/src/compile.ts
@@ -231,7 +231,7 @@ export function compile(
             toExpr(node.expression),
             ts.factory.createArrayLiteralExpression(
               node.arguments.map((arg, i) =>
-                newExpr("ArgumentExpr", [
+                newExpr("Argument", [
                   toExpr(arg),
                   // the arguments array may not match the signature or the signature may be unknown
                   signature?.parameters?.[i]?.name

--- a/src/expression.ts
+++ b/src/expression.ts
@@ -9,6 +9,7 @@ import { AnyFunction } from "./util";
  * An {@link Expr} (Expression) is a Node that will be interpreted to a value.
  */
 export type Expr =
+  | ArgumentExpr
   | ArrayLiteralExpr
   | BinaryExpr
   | BooleanLiteralExpr
@@ -27,13 +28,13 @@ export type Expr =
   | SpreadAssignExpr
   | SpreadElementExpr
   | TemplateExpr
-  | UnaryExpr
-  | ArgumentExpr;
+  | UnaryExpr;
 
 export function isExpr(a: any) {
   return (
     isNode(a) &&
-    (isArrayLiteralExpr(a) ||
+    (isArgumentExpr(a) ||
+      isArrayLiteralExpr(a) ||
       isBinaryExpr(a) ||
       isBooleanLiteral(a) ||
       isCallExpr(a) ||
@@ -49,8 +50,7 @@ export function isExpr(a: any) {
       isReferenceExpr(a) ||
       isStringLiteralExpr(a) ||
       isTemplateExpr(a) ||
-      isUnaryExpr(a) ||
-      isArgumentExpr(a))
+      isUnaryExpr(a))
   );
 }
 

--- a/src/expression.ts
+++ b/src/expression.ts
@@ -120,7 +120,7 @@ export class CallExpr extends BaseNode<"CallExpr"> {
     args.forEach((arg) => setParent(this, arg));
   }
 
-  getArgument(name: string): Argument | undefined {
+  public getArgument(name: string): Argument | undefined {
     return this.args.find((arg) => arg.name === name);
   }
 }

--- a/src/expression.ts
+++ b/src/expression.ts
@@ -9,7 +9,7 @@ import { AnyFunction } from "./util";
  * An {@link Expr} (Expression) is a Node that will be interpreted to a value.
  */
 export type Expr =
-  | ArgumentExpr
+  | Argument
   | ArrayLiteralExpr
   | BinaryExpr
   | BooleanLiteralExpr
@@ -33,7 +33,7 @@ export type Expr =
 export function isExpr(a: any) {
   return (
     isNode(a) &&
-    (isArgumentExpr(a) ||
+    (isArgument(a) ||
       isArrayLiteralExpr(a) ||
       isBinaryExpr(a) ||
       isBooleanLiteral(a) ||
@@ -101,11 +101,11 @@ export class ElementAccessExpr extends BaseNode<"ElementAccessExpr"> {
   }
 }
 
-export const isArgumentExpr = typeGuard("ArgumentExpr");
+export const isArgument = typeGuard("Argument");
 
-export class ArgumentExpr extends BaseNode<"ArgumentExpr"> {
+export class Argument extends BaseNode<"Argument"> {
   constructor(readonly expr: Expr, readonly name?: string) {
-    super("ArgumentExpr");
+    super("Argument");
     setParent(this, expr);
   }
 }
@@ -113,14 +113,14 @@ export class ArgumentExpr extends BaseNode<"ArgumentExpr"> {
 export const isCallExpr = typeGuard("CallExpr");
 
 export class CallExpr extends BaseNode<"CallExpr"> {
-  constructor(readonly expr: Expr, readonly args: ArgumentExpr[]) {
+  constructor(readonly expr: Expr, readonly args: Argument[]) {
     super("CallExpr");
     expr.parent = this;
 
     args.forEach((arg) => setParent(this, arg));
   }
 
-  getArgument(name: string): ArgumentExpr | undefined {
+  getArgument(name: string): Argument | undefined {
     return this.args.find((arg) => arg.name === name);
   }
 }

--- a/src/function.ts
+++ b/src/function.ts
@@ -36,8 +36,8 @@ export class Function<P, O> {
     return Object.assign(lambda, this);
 
     function lambda(call: CallExpr, vtl: VTL): string {
-      const payload =
-        "payload" in call.args ? vtl.eval(call.args.payload) : "$null";
+      const payloadArg = call.getArgument("payload");
+      const payload = payloadArg ? vtl.eval(payloadArg.expr) : "$null";
 
       const request = vtl.var(
         `{"version": "2018-05-29", "operation": "Invoke", "payload": ${payload}}`

--- a/src/table.ts
+++ b/src/table.ts
@@ -9,12 +9,13 @@ import {
 } from "typesafe-dynamodb/lib/expression-attributes";
 import { TableKey } from "typesafe-dynamodb/lib/key";
 import { Narrow } from "typesafe-dynamodb/lib/narrow";
-import { CallExpr } from "./expression";
+import { CallExpr, ObjectLiteralExpr } from "./expression";
 import { VTL } from "./vtl";
 
 // @ts-ignore - imported for typedoc
 import type { AppsyncResolver } from "./appsync";
 import { JsonFormat } from "typesafe-dynamodb";
+import { assertNodeKind } from "./assert";
 
 export function isTable(a: any): a is AnyTable {
   return a?.kind === "Table";
@@ -89,7 +90,12 @@ export class Table<
   }): Narrow<Item, AttributeKeyToObject<Key>, JsonFormat.Document>;
 
   public getItem(call: CallExpr, vtl: VTL): any {
-    const input = vtl.eval(call.args.input);
+    const input = vtl.eval(
+      assertNodeKind<ObjectLiteralExpr>(
+        call.getArgument("input")?.expr,
+        "ObjectLiteralExpr"
+      )
+    );
     const request = vtl.var(
       `{"operation": "GetItem", "version": "2018-05-29"}`
     );
@@ -124,7 +130,12 @@ export class Table<
   }): Narrow<Item, AttributeKeyToObject<Key>, JsonFormat.Document>;
 
   public putItem(call: CallExpr, vtl: VTL): any {
-    const input = vtl.eval(call.args.input);
+    const input = vtl.eval(
+      assertNodeKind<ObjectLiteralExpr>(
+        call.getArgument("input")?.expr,
+        "ObjectLiteralExpr"
+      )
+    );
     const request = vtl.var(
       `{"operation": "PutItem", "version": "2018-05-29"}`
     );
@@ -159,7 +170,12 @@ export class Table<
   }): Narrow<Item, AttributeKeyToObject<Key>, JsonFormat.Document>;
 
   public updateItem(call: CallExpr, vtl: VTL): any {
-    const input = vtl.eval(call.args.input);
+    const input = vtl.eval(
+      assertNodeKind<ObjectLiteralExpr>(
+        call.getArgument("input")?.expr,
+        "ObjectLiteralExpr"
+      )
+    );
     const request = vtl.var(
       `{"operation": "UpdateItem", "version": "2018-05-29"}`
     );
@@ -190,7 +206,12 @@ export class Table<
   }): Narrow<Item, AttributeKeyToObject<Key>, JsonFormat.Document>;
 
   public deleteItem(call: CallExpr, vtl: VTL): any {
-    const input = vtl.eval(call.args.input);
+    const input = vtl.eval(
+      assertNodeKind<ObjectLiteralExpr>(
+        call.getArgument("input")?.expr,
+        "ObjectLiteralExpr"
+      )
+    );
     const request = vtl.var(
       `{"operation": "DeleteItem", "version": "2018-05-29"}`
     );
@@ -221,7 +242,12 @@ export class Table<
   };
 
   public query(call: CallExpr, vtl: VTL): any {
-    const input = vtl.eval(call.args.input);
+    const input = vtl.eval(
+      assertNodeKind<ObjectLiteralExpr>(
+        call.getArgument("input")?.expr,
+        "ObjectLiteralExpr"
+      )
+    );
     const request = vtl.var(`{"operation": "Query", "version": "2018-05-29"}`);
     vtl.qr(`${request}.put('key', ${input}.get('key'))`);
     vtl.qr(`${request}.put('query', ${input}.get('query'))`);

--- a/src/vtl.ts
+++ b/src/vtl.ts
@@ -420,7 +420,7 @@ export class VTL {
         }
       case "Err":
         throw node.error;
-      case "ArgumentExpr":
+      case "Argument":
         return this.eval(node.expr);
     }
 


### PR DESCRIPTION
Support positional arguments in methods with unknown names (any function, user defined interface, etc) by changing args to a array of `ArgumentExpr` instead of a Map.

Also pulls forward support for type casting (`x as any`, `<any>x`) and parenthesized expressions (`1 + (2 + 3)`) from the #39 PR.

### Before 
```ts
const fn = assertNodeKind<FunctionDecl>(reflect(() => "".startsWith("")));

const return = assertNodeKind<RetunStmt>(fn.body.statements[0], "ReturnStmt");
const call = assertNodeKind<CallExpr>(return.expr, "CallExpr");

assertNodeType<StringLiteralExpr>(call.args.searchSearch, "StringLiteralExpr");
```

### After

```ts
const fn = assertNodeKind<FunctionDecl>(reflect(() => "".startsWith("")));

const return = assertNodeKind<RetunStmt>(fn.body.statements[0], "ReturnStmt");
const call = assertNodeKind<CallExpr>(return.expr, "CallExpr");

assertNodeType<StringLiteralExpr>(call.getArgument("searchSearch")?.expr, "StringLiteralExpr");
```

### Now supports

```ts
const fn = assertNodeKind<FunctionDecl>(reflect(() => ("" as any).startsWith("")));

const return = assertNodeKind<RetunStmt>(fn.body.statements[0], "ReturnStmt");
const call = assertNodeKind<CallExpr>(return.expr, "CallExpr");

assertNodeType<StringLiteralExpr>(call.args[0].expr, "StringLiteralExpr");
```

BREAKING CHANGE: `CallExpr` now contains an array of `ArgumentExpr` and a `getArgument` method instead of a map of argument name to expression. Arguments present in the signature but not that call will not be present in the array.