### PR TITLE
feat: split undefined, null, and support computed object names

### DIFF
--- a/src/compile.ts
+++ b/src/compile.ts
@@ -198,7 +198,7 @@ export function compile(
 
       function toExpr(node: ts.Node | undefined): ts.Expression {
         if (node === undefined) {
-          return newExpr("NullLiteralExpr", []);
+          return newExpr("UndefinedLiteralExpr", []);
         } else if (ts.isArrowFunction(node) || ts.isFunctionExpression(node)) {
           return toFunction("FunctionExpr", node);
         } else if (ts.isExpressionStatement(node)) {
@@ -250,7 +250,9 @@ export function compile(
             ),
           ]);
         } else if (ts.isIdentifier(node)) {
-          if (node.text === "undefined" || node.text === "null") {
+          if (node.text === "undefined") {
+            return newExpr("UndefinedLiteralExpr", []);
+          } else if (node.text === "null") {
             return newExpr("NullLiteralExpr", []);
           }
           const kind = getKind(node);
@@ -343,11 +345,11 @@ export function compile(
             (ts.isIdentifier(node.name) &&
               (node.name.text === "null" || node.name.text === "undefined"))
               ? string(node.name.text)
-              : ts.isComputedPropertyName(node.name)
-              ? toExpr(node.name.expression)
               : toExpr(node.name),
             toExpr(node.initializer),
           ]);
+        } else if (ts.isComputedPropertyName(node)) {
+          return newExpr("ComputedPropertyNameExpr", [toExpr(node.expression)]);
         } else if (ts.isShorthandPropertyAssignment(node)) {
           return newExpr("PropAssignExpr", [
             newExpr("Identifier", [

--- a/src/expression.ts
+++ b/src/expression.ts
@@ -15,6 +15,7 @@ export type Expr =
   | BooleanLiteralExpr
   | CallExpr
   | ConditionExpr
+  | ComputedPropertyNameExpr
   | FunctionExpr
   | ElementAccessExpr
   | Identifier
@@ -28,7 +29,8 @@ export type Expr =
   | SpreadAssignExpr
   | SpreadElementExpr
   | TemplateExpr
-  | UnaryExpr;
+  | UnaryExpr
+  | UndefinedLiteralExpr;
 
 export function isExpr(a: any) {
   return (
@@ -39,6 +41,7 @@ export function isExpr(a: any) {
       isBooleanLiteral(a) ||
       isCallExpr(a) ||
       isConditionExpr(a) ||
+      isComputedPropertyNameExpr(a) ||
       isFunctionExpr(a) ||
       isElementAccessExpr(a) ||
       isIdentifier(a) ||
@@ -50,7 +53,8 @@ export function isExpr(a: any) {
       isReferenceExpr(a) ||
       isStringLiteralExpr(a) ||
       isTemplateExpr(a) ||
-      isUnaryExpr(a))
+      isUnaryExpr(a) ||
+      isUndefinedLiteralExpr(a))
   );
 }
 
@@ -186,6 +190,14 @@ export class NullLiteralExpr extends BaseNode<"NullLiteralExpr"> {
   }
 }
 
+export const isUndefinedLiteralExpr = typeGuard("UndefinedLiteralExpr");
+
+export class UndefinedLiteralExpr extends BaseNode<"UndefinedLiteralExpr"> {
+  constructor() {
+    super("UndefinedLiteralExpr");
+  }
+}
+
 export const isBooleanLiteral = typeGuard("BooleanLiteralExpr");
 
 export class BooleanLiteralExpr extends BaseNode<"BooleanLiteralExpr"> {
@@ -228,23 +240,27 @@ export class ObjectLiteralExpr extends BaseNode<"ObjectLiteralExpr"> {
     super("ObjectLiteralExpr");
     setParent(this, properties);
   }
-
-  public getProperty(name: string) {
-    return this.properties.find(
-      (prop) =>
-        prop.kind === "PropAssignExpr" &&
-        ((prop.name.kind === "Identifier" && prop.name.name === name) ||
-          (prop.name.kind === "StringLiteralExpr" && prop.name.value === name))
-    );
-  }
 }
 
 export const isPropAssignExpr = typeGuard("PropAssignExpr");
 
 export class PropAssignExpr extends BaseNode<"PropAssignExpr"> {
-  constructor(readonly name: Expr, readonly expr: Expr) {
+  constructor(
+    readonly name: Identifier | ComputedPropertyNameExpr,
+    readonly expr: Expr
+  ) {
     super("PropAssignExpr");
-    expr.parent = this;
+    setParent(this, name);
+    setParent(this, expr);
+  }
+}
+
+export const isComputedPropertyNameExpr = typeGuard("ComputedPropertyNameExpr");
+
+export class ComputedPropertyNameExpr extends BaseNode<"ComputedPropertyNameExpr"> {
+  constructor(readonly expr: Expr) {
+    super("ComputedPropertyNameExpr");
+    setParent(this, expr);
   }
 }
 

--- a/src/vtl.ts
+++ b/src/vtl.ts
@@ -350,6 +350,7 @@ export class VTL {
       case "ElementAccessExpr":
         return `${this.eval(node.expr)}[${this.eval(node.element)}]`;
       case "NullLiteralExpr":
+      case "UndefinedLiteralExpr":
         return "$null";
       case "NumberLiteralExpr":
         return node.value.toString(10);
@@ -360,8 +361,6 @@ export class VTL {
             const name =
               prop.name.kind === "Identifier"
                 ? `'${prop.name.name}'`
-                : prop.name.kind === "StringLiteralExpr"
-                ? `'${prop.name.value}'`
                 : this.eval(prop.name);
             this.qr(`${obj}.put(${name}, ${this.eval(prop.expr)})`);
           } else if (prop.kind === "SpreadAssignExpr") {
@@ -372,6 +371,8 @@ export class VTL {
         }
         return obj;
       }
+      case "ComputedPropertyNameExpr":
+        return this.eval(node.expr);
       case "ParameterDecl":
       case "PropAssignExpr":
       case "ReferenceExpr":

--- a/test/reflect.test.ts
+++ b/test/reflect.test.ts
@@ -1,12 +1,16 @@
 import {
   BinaryExpr,
   CallExpr,
+  Err,
   ExprStmt,
   FunctionDecl,
+  NullLiteralExpr,
   NumberLiteralExpr,
+  ObjectLiteralExpr,
   reflect,
   ReturnStmt,
   StringLiteralExpr,
+  UndefinedLiteralExpr,
 } from "../src";
 import { assertNodeKind } from "../src/assert";
 
@@ -123,5 +127,58 @@ test("named function args", () => {
 
   expect(call.getArgument("searchString")?.expr.kind).toEqual(
     "StringLiteralExpr"
+  );
+});
+
+test("null", () => {
+  const result = assertNodeKind<FunctionDecl>(
+    reflect(() => null),
+    "FunctionDecl"
+  );
+
+  const ret = assertNodeKind<ReturnStmt>(
+    result.body.statements[0],
+    "ReturnStmt"
+  );
+  assertNodeKind<NullLiteralExpr>(ret.expr, "NullLiteralExpr");
+});
+
+test("undefined", () => {
+  const result = assertNodeKind<FunctionDecl>(
+    reflect(() => undefined),
+    "FunctionDecl"
+  );
+
+  const ret = assertNodeKind<ReturnStmt>(
+    result.body.statements[0],
+    "ReturnStmt"
+  );
+  assertNodeKind<UndefinedLiteralExpr>(ret.expr, "UndefinedLiteralExpr");
+});
+
+test("computed object name", () => {
+  const result = assertNodeKind<FunctionDecl>(
+    reflect(() => {
+      const name = "aName";
+      return {
+        [name]: "value",
+      };
+    }),
+    "FunctionDecl"
+  );
+
+  const ret = assertNodeKind<ReturnStmt>(
+    result.body.statements[1],
+    "ReturnStmt"
+  );
+  const obj = assertNodeKind<ObjectLiteralExpr>(ret.expr, "ObjectLiteralExpr");
+  obj.properties
+});
+
+test("err", () => {
+  const fn = () => {};
+  const result = assertNodeKind<Err>(reflect(fn), "Err");
+  expect(result.error.message).toEqual(
+    "Functionless reflection only supports function parameters with bodies, no signature only declarations or references. Found fn."
   );
 });

--- a/test/vtl.test.ts
+++ b/test/vtl.test.ts
@@ -30,7 +30,7 @@ test("return literal object with values", () => {
           undefined: undefined,
           string: "hello",
           number: 1,
-          list: ["hello"],
+          ["list"]: ["hello"],
           obj: {
             key: "value",
           },
@@ -53,6 +53,46 @@ $util.qr($v2.put('key', 'value'))
 $util.qr($v1.put('obj', $v2))
 $util.qr($v1.put('arg', $context.stash.arg))
 $util.qr($v1.putAll($context.stash.obj))
+#return($v1)`
+  );
+});
+
+test("computed property names", () => {
+  appsyncTestCase(
+    reflect(
+      (context: AppsyncContext<{ arg: string; obj: Record<string, any> }>) => {
+        const name = context.arguments.arg;
+        const value = name + "_test";
+        return {
+          [name]: context.arguments.arg,
+          [value]: context.arguments.arg,
+        };
+      }
+    ),
+    payload,
+    `#set($context.stash.name = $context.arguments.arg)
+#set($context.stash.value = $context.stash.name + '_test')
+#set($v1 = {})
+$util.qr($v1.put($context.stash.name, $context.arguments.arg))
+$util.qr($v1.put($context.stash.value, $context.arguments.arg))
+#return($v1)`
+  );
+});
+
+test("null and undefined", () => {
+  appsyncTestCase(
+    reflect(
+      (_context: AppsyncContext<{ arg: string; obj: Record<string, any> }>) => {
+        return {
+          name: null,
+          value: undefined,
+        };
+      }
+    ),
+    payload,
+    `#set($v1 = {})
+$util.qr($v1.put('name', $null))
+$util.qr($v1.put('value', $null))
 #return($v1)`
   );
 });


### PR DESCRIPTION
Closes #52

BREAKING CHANGE: Null and Undefined are now split into NullLiteralExpr and UndefinedLiteralExpr.
BREAKING CHANGE: PropertAssignExpr can contain a new expression node call ComputedPropertyNameExpr which contains any expression that can be used to assign a dynamic proeprty name on an object.