### PR TITLE
feat: add $util.time helpers to appsync

### DIFF
--- a/src/appsync.ts
+++ b/src/appsync.ts
@@ -686,7 +686,7 @@ export interface time {
   parseFormattedToEpochMilliSeconds(
     timestamp: string,
     format: string,
-    tiemzeone: string
+    timezone: string
   ): number;
 
   /**
@@ -713,7 +713,7 @@ export interface time {
    * Converts a epoch milliseconds timestamp, passed as a long, to a timestamp formatted according to the supplied format in the supplied timezone.
    */
   epochMilliSecondsToFormatted(
-    epoc: number,
+    epoch: number,
     format: string,
     timezone: string
   ): string;

--- a/src/appsync.ts
+++ b/src/appsync.ts
@@ -448,6 +448,13 @@ export interface $util {
   readonly dynamodb: dynamodb;
 
   /**
+   * The $util.time variable contains datetime methods to help generate timestamps, convert between datetime formats, and parse datetime strings. The syntax for datetime formats is based on DateTimeFormatter which you can reference for further documentation. Below we provide some examples, as well as a list of available methods and descriptions.
+   *
+   * @see https://docs.aws.amazon.com/appsync/latest/devguide/time-helpers-in-util-time.html
+   */
+  readonly time: time;
+
+  /**
    * Returns the input string as a JavaScript escaped string.
    */
   escapeJavaScript(js: string): string;
@@ -640,6 +647,76 @@ export interface $util {
    * Returns a string describing the multi-auth type being used by a request, returning back either "IAM Authorization", "User Pool Authorization", "Open ID Connect Authorization", or "API Key Authorization".
    */
   authType(): string;
+}
+
+export interface time {
+  /**
+   * Returns a String representation of UTC in ISO8601 format.
+   */
+  nowISO8601(): string;
+
+  /**
+   * Returns the number of seconds from the epoch of 1970-01-01T00:00:00Z to now.
+   */
+  nowEpochSeconds(): number;
+
+  /**
+   * Returns the number of milliseconds from the epoch of 1970-01-01T00:00:00Z to now.
+   */
+  nowEpochMilliSeconds(): number;
+
+  /**
+   * Returns a string of the current timestamp in UTC using the specified format from a String input type.
+   */
+  nowFormatted(format: string): string;
+
+  /**
+   * Returns a string of the current timestamp for a timezone using the specified format and timezone from String input types.
+   */
+  nowFormatted(format: string, timezone: string): string;
+
+  /**
+   * Parses a timestamp passed as a String, along with a format, and return the timestamp as milliseconds since epoch.
+   */
+  parseFormattedToEpochMilliSeconds(timestamp: string, format: string): number;
+
+  /**
+   * Parses a timestamp passed as a String, along with a format and time zone, and return the timestamp as milliseconds since epoch.
+   */
+  parseFormattedToEpochMilliSeconds(
+    timestamp: string,
+    format: string,
+    tiemzeone: string
+  ): number;
+
+  /**
+   * Parses an ISO8601 timestamp, passed as a String, and return the timestamp as milliseconds since epoch.
+   */
+  parseISO8601ToEpochMilliSeconds(timestamp: string): number;
+
+  /**
+   * Converts an epoch milliseconds timestamp to an epoch seconds timestamp.
+   */
+  epochMilliSecondsToSeconds(epoch: number): number;
+
+  /**
+   * Converts a epoch milliseconds timestamp to an ISO8601 timestamp.
+   */
+  epochMilliSecondsToISO8601(epoch: number): string;
+
+  /**
+   * Converts a epoch milliseconds timestamp, passed as long, to a timestamp formatted according to the supplied format in UTC.
+   */
+  epochMilliSecondsToFormatted(epoch: number, format: string): string;
+
+  /**
+   * Converts a epoch milliseconds timestamp, passed as a long, to a timestamp formatted according to the supplied format in the supplied timezone.
+   */
+  epochMilliSecondsToFormatted(
+    epoc: number,
+    format: string,
+    timezone: string
+  ): string;
 }
 
 const dataSourcesSymbol = Symbol.for("functionless.DataSources");

--- a/test/vtl.test.ts
+++ b/test/vtl.test.ts
@@ -599,3 +599,12 @@ $util.qr($v6.add($item))
 #end
 #return($v1)`
   ));
+
+test("$util.time.nowISO8601", () =>
+  appsyncTestCase(
+    reflect(() => {
+      return $util.time.nowISO8601();
+    }),
+    payload,
+    "#return($util.time.nowISO8601())"
+  ));


### PR DESCRIPTION
While building a sample application, I noticed that `$util.time` was missing, which is extremely important for almost all use-cases. Quickly adding it in.

```ts
() => {
  return $util.time.nowISO8601();
}
```