### PR TITLE
fix: generate a unique name for all DataSources and Appsync Functions within a GraphQL API

### DIFF
--- a/test-app/schema.gql
+++ b/test-app/schema.gql
@@ -13,5 +13,6 @@ input PersonInput {
 type Mutation {
   deletePerson(id: ID!): Person
   addPerson(input: PersonInput!): Person
+  addPerson2(input: PersonInput!): Person
   updateName(id: ID!, name: String!): Person
 }

--- a/test-app/src/app.ts
+++ b/test-app/src/app.ts
@@ -35,6 +35,12 @@ peopleDb.addPerson.addResolver(api, {
   fieldName: "addPerson",
 });
 
+// add a duplicate addPerson API to test duplicates
+peopleDb.addPerson.addResolver(api, {
+  typeName: "Mutation",
+  fieldName: "addPerson2",
+});
+
 peopleDb.updateName.addResolver(api, {
   typeName: "Mutation",
   fieldName: "updateName",


### PR DESCRIPTION
Fixes #63 

There was a bug where if two AppsyncResolvers within a single GraphQL API made the same API call to the same Data Source, we would generate the same Construct name for them which would throw a "Construct already exists error".

This change reworks that logic to store a global WeakMap of GraphQLAPI to a map of name->count to deterministically generate unique names.