### PR TITLE
feat: step function object parameter, start step function invocation from event bridge

### DIFF
--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -33,6 +33,10 @@
       "type": "build"
     },
     {
+      "name": "amplify-appsync-simulator",
+      "type": "build"
+    },
+    {
       "name": "aws-cdk-lib",
       "version": "2.17.0",
       "type": "build"

--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -241,7 +241,7 @@
           "exec": "yarn install --check-files"
         },
         {
-          "exec": "yarn upgrade @aws-cdk/aws-appsync-alpha @types/fs-extra @types/jest @types/minimatch @types/node @typescript-eslint/eslint-plugin @typescript-eslint/parser aws-cdk-lib constructs eslint-import-resolver-node eslint-import-resolver-typescript eslint-plugin-import eslint jest jest-junit json-schema npm-check-updates standard-version ts-jest ts-node ts-patch typesafe-dynamodb typescript @aws-cdk/aws-appsync-alpha aws-cdk-lib constructs typesafe-dynamodb typescript fs-extra minimatch"
+          "exec": "yarn upgrade @aws-cdk/aws-appsync-alpha @types/fs-extra @types/jest @types/minimatch @types/node @typescript-eslint/eslint-plugin @typescript-eslint/parser amplify-appsync-simulator aws-cdk-lib constructs eslint-import-resolver-node eslint-import-resolver-typescript eslint-plugin-import eslint jest jest-junit json-schema npm-check-updates standard-version ts-jest ts-node ts-patch typesafe-dynamodb typescript @aws-cdk/aws-appsync-alpha aws-cdk-lib constructs typesafe-dynamodb typescript fs-extra minimatch"
         },
         {
           "exec": "npx projen"

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -7,6 +7,7 @@ const project = new typescript.TypeScriptProject({
     "@aws-cdk/aws-appsync-alpha",
     "@types/fs-extra",
     "@types/minimatch",
+    "amplify-appsync-simulator",
     "aws-cdk-lib",
     "constructs",
     "ts-node",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@types/node": "^12",
     "@typescript-eslint/eslint-plugin": "^5",
     "@typescript-eslint/parser": "^5",
+    "amplify-appsync-simulator": "^2.3.10",
     "aws-cdk-lib": "2.17.0",
     "constructs": "10.0.0",
     "eslint": "^8",

--- a/src/asl.ts
+++ b/src/asl.ts
@@ -1377,6 +1377,22 @@ export namespace ASL {
     }
   }
 
+  /**
+   * Returns a object with the key formatted based on the contents of the value.
+   * in ASL, object keys that reference json path values must have a suffix of ".$"
+   * { "input.$": "$.value" }
+   */
+  export function toJsonAssignment(
+    key: string,
+    expr: Expr
+  ): Record<string, any> {
+    const value = ASL.toJson(expr);
+
+    return {
+      [isVariableReference(expr) ? `${key}.$` : key]: value,
+    };
+  }
+
   function filterToJsonPath(expr: CallExpr & { expr: PropAccessExpr }): string {
     const predicate = expr.getArgument("predicate")?.expr;
     if (predicate?.kind !== "FunctionExpr") {

--- a/src/asl.ts
+++ b/src/asl.ts
@@ -1335,13 +1335,9 @@ export namespace ASL {
     } else if (expr.kind === "Identifier") {
       const ref = expr.lookup();
       // If the identifier references a parameter expression and that parameter expression
-      // is in a FunctionExpr or FunctionDecl and that Function is at the top (no parent).
-      if (
-        ref &&
-        isParameterDecl(ref) &&
-        anyOf(isFunctionExpr, isFunctionDecl)(ref.parent) &&
-        ref.parent.parent === undefined
-      ) {
+      // is in a FunctionDecl and that Function is at the top (no parent).
+      // This logic needs to be updated to support destructured inputs: https://github.com/sam-goodwin/functionless/issues/68
+      if (ref && isParameterDecl(ref) && isFunctionDecl(ref.parent)) {
         return "$";
       }
       return `$.${expr.name}`;

--- a/src/assert.ts
+++ b/src/assert.ts
@@ -1,4 +1,5 @@
 import { FunctionlessNode } from "./node";
+import { ConstantValue, PrimitiveValue, isPrimitive } from "./util";
 
 export function assertNever(value: never): never {
   throw new Error(
@@ -30,6 +31,38 @@ export function assertDefined<T>(
     throw new Error(message ?? "Expected value to be present");
   }
   return value as Exclude<T, undefined>;
+}
+
+export function assertPrimitive(val: any, message?: string): PrimitiveValue {
+  if (isPrimitive(val === "string")) {
+    return val;
+  }
+
+  throw Error(
+    message ?? `Expected value to be a primitve, found ${typeof val}`
+  );
+}
+
+export function assertConstantValue(val: any, message?: string): ConstantValue {
+  if (isPrimitive(val)) {
+    return val;
+  } else if (typeof val === "object") {
+    if (Array.isArray(val)) {
+      return val.map((i) => assertConstantValue(i));
+    } else {
+      return Object.entries(val).reduce(
+        (acc, [key, value]) => ({
+          ...acc,
+          [key]: assertConstantValue(value),
+        }),
+        {}
+      );
+    }
+  }
+
+  throw Error(
+    message ?? `Expected value to be a constant, found ${typeof val}`
+  );
 }
 
 export function assertNodeKind<T extends FunctionlessNode>(

--- a/src/assert.ts
+++ b/src/assert.ts
@@ -34,7 +34,7 @@ export function assertDefined<T>(
 }
 
 export function assertPrimitive(val: any, message?: string): PrimitiveValue {
-  if (isPrimitive(val === "string")) {
+  if (isPrimitive(val)) {
     return val;
   }
 

--- a/src/aws.ts
+++ b/src/aws.ts
@@ -22,7 +22,8 @@ import {
 import { ASL, isASL, Task } from "./asl";
 import { CallContext } from "./context";
 import { VTL } from "./vtl";
-import { Function } from "./function";
+import { Function, isFunction } from "./function";
+import { isTable } from "./table";
 
 import type { DynamoDB as AWSDynamoDB } from "aws-sdk";
 
@@ -45,6 +46,10 @@ type RangeKey<T extends Table<any, any, any>> = T extends Table<
 >
   ? SK
   : never;
+
+export function isAWS(a: any): a is typeof $AWS {
+  return a?.kind === "AWS";
+}
 
 /**
  * The `AWS` namespace exports functions that map to AWS Step Functions AWS-SDK Integrations.
@@ -294,7 +299,7 @@ export namespace $AWS {
       }
 
       const table = tableProp.expr.ref();
-      if (table.kind !== "Table") {
+      if (!isTable(table)) {
         throw new Error(``);
       }
       if (
@@ -348,7 +353,7 @@ export namespace $AWS {
         );
       }
       const functionRef = functionName.ref();
-      if (functionRef.kind !== "Function") {
+      if (!isFunction(functionRef)) {
         throw new Error(
           `property 'FunctionName' must reference a functionless.Function`
         );

--- a/src/compile.ts
+++ b/src/compile.ts
@@ -6,6 +6,7 @@ import { FunctionlessNode } from "./node";
 import { AppsyncResolver } from "./appsync";
 import { assertDefined } from "./assert";
 import { StepFunction, ExpressStepFunction } from "./step-function";
+import { hasParent } from "./util";
 import minimatch from "minimatch";
 import { EventBus, EventBusRule } from "./event-bridge";
 import { EventBusTransform } from "./event-bridge/transform";
@@ -390,10 +391,10 @@ export function compile(
           );
         }
         const body = ts.isBlock(impl.body)
-          ? toExpr(impl.body)
+          ? toExpr(impl.body, impl)
           : newExpr("BlockStmt", [
               ts.factory.createArrayLiteralExpression([
-                newExpr("ReturnStmt", [toExpr(impl.body)]),
+                newExpr("ReturnStmt", [toExpr(impl.body, impl)]),
               ]),
             ]);
 
@@ -409,13 +410,16 @@ export function compile(
         ]);
       }
 
-      function toExpr(node: ts.Node | undefined): ts.Expression {
+      function toExpr(
+        node: ts.Node | undefined,
+        scope: ts.Node
+      ): ts.Expression {
         if (node === undefined) {
-          return newExpr("UndefinedLiteralExpr", []);
+          return ts.factory.createIdentifier("undefined");
         } else if (ts.isArrowFunction(node) || ts.isFunctionExpression(node)) {
           return toFunction("FunctionExpr", node);
         } else if (ts.isExpressionStatement(node)) {
-          return newExpr("ExprStmt", [toExpr(node.expression)]);
+          return newExpr("ExprStmt", [toExpr(node.expression, scope)]);
         } else if (ts.isCallExpression(node) || ts.isNewExpression(node)) {
           const exprType = checker.getTypeAtLocation(node.expression);
           const functionBrand = exprType.getProperty("__functionBrand");
@@ -442,7 +446,7 @@ export function compile(
           }
           if (signature && signature.parameters.length > 0) {
             return newExpr(ts.isCallExpression(node) ? "CallExpr" : "NewExpr", [
-              toExpr(node.expression),
+              toExpr(node.expression, scope),
               ts.factory.createArrayLiteralExpression(
                 signature.parameters.map((parameter, i) =>
                   newExpr("Argument", [
@@ -450,10 +454,12 @@ export function compile(
                       ?.dotDotDotToken
                       ? newExpr("ArrayLiteralExpr", [
                           ts.factory.createArrayLiteralExpression(
-                            node.arguments?.slice(i).map(toExpr) ?? []
+                            node.arguments
+                              ?.slice(i)
+                              .map((x) => toExpr(x, scope)) ?? []
                           ),
                         ])
-                      : toExpr(node.arguments?.[i]),
+                      : toExpr(node.arguments?.[i], scope),
                     ts.factory.createStringLiteral(parameter.name),
                   ])
                 )
@@ -461,11 +467,11 @@ export function compile(
             ]);
           } else {
             return newExpr("CallExpr", [
-              toExpr(node.expression),
+              toExpr(node.expression, scope),
               ts.factory.createArrayLiteralExpression(
                 node.arguments?.map((arg) =>
                   newExpr("Argument", [
-                    toExpr(arg),
+                    toExpr(arg, scope),
                     ts.factory.createIdentifier("undefined"),
                   ])
                 ) ?? []
@@ -475,7 +481,7 @@ export function compile(
         } else if (ts.isBlock(node)) {
           return newExpr("BlockStmt", [
             ts.factory.createArrayLiteralExpression(
-              node.statements.map(toExpr)
+              node.statements.map((x) => toExpr(x, scope))
             ),
           ]);
         } else if (ts.isIdentifier(node)) {
@@ -490,6 +496,23 @@ export function compile(
             return ref(node);
           }
 
+          const symbol = checker.getSymbolAtLocation(node);
+          /**
+           * If the identifier is not within the closure, we attempt to enclose the reference in its own closure.
+           * cosnt val = "hello";
+           * reflect(() => return { value: val }; );
+           *
+           * result
+           *
+           * return { value: () => val };
+           */
+          if (symbol) {
+            const ref = outOfScopeIdentifierToRef(symbol, scope);
+            if (ref) {
+              return ref;
+            }
+          }
+
           return newExpr("Identifier", [
             ts.factory.createStringLiteral(node.text),
           ]);
@@ -501,7 +524,7 @@ export function compile(
           }
           const type = checker.getTypeAtLocation(node.name);
           return newExpr("PropAccessExpr", [
-            toExpr(node.expression),
+            toExpr(node.expression, scope),
             ts.factory.createStringLiteral(node.name.text),
             type
               ? ts.factory.createStringLiteral(checker.typeToString(type))
@@ -510,8 +533,8 @@ export function compile(
         } else if (ts.isElementAccessExpression(node)) {
           const type = checker.getTypeAtLocation(node.argumentExpression);
           return newExpr("ElementAccessExpr", [
-            toExpr(node.expression),
-            toExpr(node.argumentExpression),
+            toExpr(node.expression, scope),
+            toExpr(node.argumentExpression, scope),
             type
               ? ts.factory.createStringLiteral(checker.typeToString(type))
               : ts.factory.createIdentifier("undefined"),
@@ -520,29 +543,29 @@ export function compile(
           ts.isVariableStatement(node) &&
           node.declarationList.declarations.length === 1
         ) {
-          return toExpr(node.declarationList.declarations[0]);
+          return toExpr(node.declarationList.declarations[0], scope);
         } else if (ts.isVariableDeclaration(node)) {
           return newExpr("VariableStmt", [
             ts.factory.createStringLiteral(node.name.getText()),
-            ...(node.initializer ? [toExpr(node.initializer)] : []),
+            ...(node.initializer ? [toExpr(node.initializer, scope)] : []),
           ]);
         } else if (ts.isIfStatement(node)) {
           return newExpr("IfStmt", [
             // when
-            toExpr(node.expression),
+            toExpr(node.expression, scope),
             // then
-            toExpr(node.thenStatement),
+            toExpr(node.thenStatement, scope),
             // else
-            ...(node.elseStatement ? [toExpr(node.elseStatement)] : []),
+            ...(node.elseStatement ? [toExpr(node.elseStatement, scope)] : []),
           ]);
         } else if (ts.isConditionalExpression(node)) {
           return newExpr("ConditionExpr", [
             // when
-            toExpr(node.condition),
+            toExpr(node.condition, scope),
             // then
-            toExpr(node.whenTrue),
+            toExpr(node.whenTrue, scope),
             // else
-            toExpr(node.whenFalse),
+            toExpr(node.whenFalse, scope),
           ]);
         } else if (ts.isBinaryExpression(node)) {
           const op = getOperator(node.operatorToken);
@@ -552,9 +575,9 @@ export function compile(
             );
           }
           return newExpr("BinaryExpr", [
-            toExpr(node.left),
+            toExpr(node.left, scope),
             ts.factory.createStringLiteral(op),
-            toExpr(node.right),
+            toExpr(node.right, scope),
           ]);
         } else if (ts.isPrefixUnaryExpression(node)) {
           if (
@@ -572,46 +595,48 @@ export function compile(
                 `Unary operator token cannot be stringified: ${node.operator}`
               )
             ),
-            toExpr(node.operand),
+            toExpr(node.operand, scope),
           ]);
         } else if (ts.isReturnStatement(node)) {
           return newExpr(
             "ReturnStmt",
             node.expression
-              ? [toExpr(node.expression)]
+              ? [toExpr(node.expression, scope)]
               : [newExpr("NullLiteralExpr", [])]
           );
         } else if (ts.isObjectLiteralExpression(node)) {
           return newExpr("ObjectLiteralExpr", [
             ts.factory.createArrayLiteralExpression(
-              node.properties.map(toExpr)
+              node.properties.map((x) => toExpr(x, scope))
             ),
           ]);
         } else if (ts.isPropertyAssignment(node)) {
           return newExpr("PropAssignExpr", [
             ts.isStringLiteral(node.name) || ts.isIdentifier(node.name)
               ? string(node.name.text)
-              : toExpr(node.name),
-            toExpr(node.initializer),
+              : toExpr(node.name, scope),
+            toExpr(node.initializer, scope),
           ]);
         } else if (ts.isComputedPropertyName(node)) {
-          return newExpr("ComputedPropertyNameExpr", [toExpr(node.expression)]);
+          return newExpr("ComputedPropertyNameExpr", [
+            toExpr(node.expression, scope),
+          ]);
         } else if (ts.isShorthandPropertyAssignment(node)) {
           return newExpr("PropAssignExpr", [
             newExpr("Identifier", [
               ts.factory.createStringLiteral(node.name.text),
             ]),
-            toExpr(node.name),
+            toExpr(node.name, scope),
           ]);
         } else if (ts.isSpreadAssignment(node)) {
-          return newExpr("SpreadAssignExpr", [toExpr(node.expression)]);
+          return newExpr("SpreadAssignExpr", [toExpr(node.expression, scope)]);
         } else if (ts.isSpreadElement(node)) {
-          return newExpr("SpreadElementExpr", [toExpr(node.expression)]);
+          return newExpr("SpreadElementExpr", [toExpr(node.expression, scope)]);
         } else if (ts.isArrayLiteralExpression(node)) {
           return newExpr("ArrayLiteralExpr", [
             ts.factory.updateArrayLiteralExpression(
               node,
-              node.elements.map(toExpr)
+              node.elements.map((x) => toExpr(x, scope))
             ),
           ]);
         } else if (node.kind === ts.SyntaxKind.NullKeyword) {
@@ -644,9 +669,9 @@ export function compile(
                 return newExpr(
                   ts.isForOfStatement(node) ? "ForOfStmt" : "ForInStmt",
                   [
-                    toExpr(varDecl),
-                    toExpr(node.expression),
-                    toExpr(node.statement),
+                    toExpr(varDecl, scope),
+                    toExpr(node.expression, scope),
+                    toExpr(node.statement, scope),
                   ]
                 );
               } else if (ts.isArrayBindingPattern(varDecl.name)) {
@@ -660,7 +685,7 @@ export function compile(
             exprs.push(string(node.head.text));
           }
           for (const span of node.templateSpans) {
-            exprs.push(toExpr(span.expression));
+            exprs.push(toExpr(span.expression, scope));
             if (span.literal.text) {
               exprs.push(string(span.literal.text));
             }
@@ -674,57 +699,57 @@ export function compile(
           return newExpr("ContinueStmt", []);
         } else if (ts.isTryStatement(node)) {
           return newExpr("TryStmt", [
-            toExpr(node.tryBlock),
+            toExpr(node.tryBlock, scope),
             node.catchClause
-              ? toExpr(node.catchClause)
+              ? toExpr(node.catchClause, scope)
               : ts.factory.createIdentifier("undefined"),
             node.finallyBlock
-              ? toExpr(node.finallyBlock)
+              ? toExpr(node.finallyBlock, scope)
               : ts.factory.createIdentifier("undefined"),
           ]);
         } else if (ts.isCatchClause(node)) {
           return newExpr("CatchClause", [
             node.variableDeclaration
-              ? toExpr(node.variableDeclaration)
+              ? toExpr(node.variableDeclaration, scope)
               : ts.factory.createIdentifier("undefined"),
-            toExpr(node.block),
+            toExpr(node.block, scope),
           ]);
         } else if (ts.isThrowStatement(node)) {
-          return newExpr("ThrowStmt", [toExpr(node.expression)]);
+          return newExpr("ThrowStmt", [toExpr(node.expression, scope)]);
         } else if (ts.isTypeOfExpression(node)) {
-          return newExpr("TypeOfExpr", [toExpr(node.expression)]);
+          return newExpr("TypeOfExpr", [toExpr(node.expression, scope)]);
         } else if (ts.isWhileStatement(node)) {
           return newExpr("WhileStmt", [
-            toExpr(node.expression),
+            toExpr(node.expression, scope),
             ts.isBlock(node.statement)
-              ? toExpr(node.statement)
+              ? toExpr(node.statement, scope)
               : // re-write a standalone statement as as BlockStmt
                 newExpr("BlockStmt", [
                   ts.factory.createArrayLiteralExpression([
-                    toExpr(node.statement),
+                    toExpr(node.statement, scope),
                   ]),
                 ]),
           ]);
         } else if (ts.isDoStatement(node)) {
           return newExpr("DoStmt", [
             ts.isBlock(node.statement)
-              ? toExpr(node.statement)
+              ? toExpr(node.statement, scope)
               : // re-write a standalone statement as as BlockStmt
                 newExpr("BlockStmt", [
                   ts.factory.createArrayLiteralExpression([
-                    toExpr(node.statement),
+                    toExpr(node.statement, scope),
                   ]),
                 ]),
-            toExpr(node.expression),
+            toExpr(node.expression, scope),
           ]);
         } else if (ts.isParenthesizedExpression(node)) {
-          return toExpr(node.expression);
+          return toExpr(node.expression, scope);
         } else if (ts.isAsExpression(node)) {
-          return toExpr(node.expression);
+          return toExpr(node.expression, scope);
         } else if (ts.isTypeAssertionExpression(node)) {
-          return toExpr(node.expression);
+          return toExpr(node.expression, scope);
         } else if (ts.isNonNullExpression(node)) {
-          return toExpr(node.expression);
+          return toExpr(node.expression, scope);
         }
 
         throw new Error(
@@ -744,6 +769,46 @@ export function compile(
             node
           ),
         ]);
+      }
+
+      /**
+       * Follow the parent of the symbol to determine if the identifier shares the same scope as the current closure being compiled.
+       * If not within the scope of the current closure, return a reference that returns the external value if possible.
+       * cosnt val = "hello";
+       * reflect(() => return { value: val }; );
+       *
+       * result
+       *
+       * return { value: () => val };
+       */
+      function outOfScopeIdentifierToRef(
+        symbol: ts.Symbol,
+        scope: ts.Node
+      ): ts.NewExpression | undefined {
+        if (symbol) {
+          if (symbol.valueDeclaration) {
+            // Identities in Shorthand Property Assignment value declarations return the shorthand prop assignment and not the value.
+            // const value = "hello"
+            // const v = { value } <== shorthand prop assignment.
+            // The checker supports getting the value assignment symbol, recursively call this method on the new symbol instead.
+            if (ts.isShorthandPropertyAssignment(symbol.valueDeclaration)) {
+              const updatedSymbol = checker.getShorthandAssignmentValueSymbol(
+                symbol.valueDeclaration
+              );
+              return updatedSymbol
+                ? outOfScopeIdentifierToRef(updatedSymbol, scope)
+                : undefined;
+            } else if (ts.isVariableDeclaration(symbol.valueDeclaration)) {
+              if (
+                symbol.valueDeclaration.initializer &&
+                !hasParent(symbol.valueDeclaration, scope)
+              ) {
+                return ref(symbol.valueDeclaration.initializer);
+              }
+            }
+          }
+        }
+        return;
       }
 
       function exprToString(node: ts.Expression): string {
@@ -774,7 +839,9 @@ export function compile(
         );
       }
 
-      function getKind(node: ts.Node): CanReference["kind"] | undefined {
+      function getKind(
+        node: ts.Node
+      ): Extract<CanReference, "kind"> | undefined {
         const exprType = checker.getTypeAtLocation(node);
         const exprKind = exprType.getProperty("kind");
         if (exprKind) {

--- a/src/compile.ts
+++ b/src/compile.ts
@@ -499,7 +499,7 @@ export function compile(
           const symbol = checker.getSymbolAtLocation(node);
           /**
            * If the identifier is not within the closure, we attempt to enclose the reference in its own closure.
-           * cosnt val = "hello";
+           * const val = "hello";
            * reflect(() => return { value: val }; );
            *
            * result
@@ -774,7 +774,7 @@ export function compile(
       /**
        * Follow the parent of the symbol to determine if the identifier shares the same scope as the current closure being compiled.
        * If not within the scope of the current closure, return a reference that returns the external value if possible.
-       * cosnt val = "hello";
+       * const val = "hello";
        * reflect(() => return { value: val }; );
        *
        * result

--- a/src/compile.ts
+++ b/src/compile.ts
@@ -787,7 +787,7 @@ export function compile(
       ): ts.NewExpression | undefined {
         if (symbol) {
           if (symbol.valueDeclaration) {
-            // Identities in Shorthand Property Assignment value declarations return the shorthand prop assignment and not the value.
+            // Identifies if Shorthand Property Assignment value declarations return the shorthand prop assignment and not the value.
             // const value = "hello"
             // const v = { value } <== shorthand prop assignment.
             // The checker supports getting the value assignment symbol, recursively call this method on the new symbol instead.

--- a/src/event-bridge/event-pattern/synth.ts
+++ b/src/event-bridge/event-pattern/synth.ts
@@ -62,6 +62,7 @@ import {
   ReferencePath,
 } from "../utils";
 import { Err, isErr } from "../../error";
+import { assertPrimitive } from "../../assert";
 
 const OPERATIONS = { STARTS_WITH: "startsWith", INCLUDES: "includes" };
 const INCLUDES_SEARCH_ELEMENT = "searchElement";
@@ -559,16 +560,22 @@ export const synthesizeEventPattern = (
   ): PatternDocument => {
     const searchElement = evalToConstant(
       assertDefined(
-        expr.args[0],
+        expr.args[0].expr,
         `Includes must have a single string argument ${INCLUDES_SEARCH_ELEMENT}.`
-      ).expr
+      )
     )?.constant;
 
     if (
       expr.args
         .map((e) => e.expr)
-        .filter((e) => !isNullLiteralExpr(e) && !isUndefinedLiteralExpr(e))
-        .length > 1
+        .filter(
+          (e) =>
+            !(
+              e === undefined ||
+              isNullLiteralExpr(e) ||
+              isUndefinedLiteralExpr(e)
+            )
+        ).length > 1
     ) {
       throw new Error(`Includes only supports the searchElement argument`);
     }
@@ -623,16 +630,22 @@ export const synthesizeEventPattern = (
     expr: CallExpr & { expr: PropAccessExpr | ElementAccessExpr }
   ): PatternDocument => {
     const arg = assertDefined(
-      expr.args[0],
+      expr.args[0].expr,
       `StartsWith must contain a single string argument ${STARTS_WITH_SEARCH_STRING}`
     );
-    const searchString = assertString(evalToConstant(arg.expr)?.constant);
+    const searchString = assertString(evalToConstant(arg)?.constant);
 
     if (
       expr.args
         .map((e) => e.expr)
-        .filter((e) => !isNullLiteralExpr(e) && !isUndefinedLiteralExpr(e))
-        .length > 1
+        .filter(
+          (e) =>
+            !(
+              e === undefined ||
+              isNullLiteralExpr(e) ||
+              isUndefinedLiteralExpr(e)
+            )
+        ).length > 1
     ) {
       throw new Error("Includes only supports the searchString argument");
     }
@@ -739,9 +752,14 @@ export const synthesizeEventPattern = (
       expr.op
     );
 
-    const { constant: value } = assertDefined(
+    const constant = assertDefined(
       evalToConstant(other),
       "Equivency must compare to a constant value."
+    );
+
+    const value = assertPrimitive(
+      constant.constant,
+      "Event Patterns can only compare primitive values"
     );
 
     if (typeof value === "undefined") {

--- a/src/event-bridge/event-pattern/synth.ts
+++ b/src/event-bridge/event-pattern/synth.ts
@@ -53,7 +53,7 @@ import {
   isUnaryExpr,
 } from "../..";
 import {
-  assertValidEventRefererence,
+  assertValidEventReference,
   EventReference,
   flattenReturnEvent,
   evalToConstant,
@@ -509,7 +509,7 @@ export const synthesizeEventPattern = (
 
     const value = assertNumber(evalToConstant(other)?.constant);
 
-    assertValidEventRefererence(eventReference, eventDecl?.name);
+    assertValidEventReference(eventReference, eventDecl?.name);
     const range = createSingleNumericRange(value, op);
     if (range) {
       return eventReferenceToPatternDocument(eventReference, range);
@@ -591,7 +591,7 @@ export const synthesizeEventPattern = (
       isPropAccessExpr(expr.expr.expr) ||
       isElementAccessExpr(expr.expr.expr)
     ) {
-      assertValidEventRefererence(eventReference, eventDecl?.name);
+      assertValidEventReference(eventReference, eventDecl?.name);
       if (expr.expr.expr.type === "number[]") {
         const num = assertNumber(searchElement);
         return eventReferenceToPatternDocument(eventReference, {
@@ -664,7 +664,7 @@ export const synthesizeEventPattern = (
       isElementAccessExpr(expr.expr.expr)
     ) {
       if (expr.expr.expr.type === "string") {
-        assertValidEventRefererence(eventReference, eventDecl?.name);
+        assertValidEventReference(eventReference, eventDecl?.name);
         return eventReferenceToPatternDocument(eventReference, {
           prefix: searchString,
         });
@@ -709,7 +709,7 @@ export const synthesizeEventPattern = (
       reference: [...eventReference.reference, value],
     };
 
-    assertValidEventRefererence(updateEventReference, eventDecl?.name);
+    assertValidEventReference(updateEventReference, eventDecl?.name);
 
     return eventReferenceToPatternDocument(updateEventReference, {
       isPresent: true,
@@ -727,7 +727,7 @@ export const synthesizeEventPattern = (
       throw Error("Expected lone property reference to reference the event.");
     }
 
-    assertValidEventRefererence(eventReference, eventDecl?.name);
+    assertValidEventReference(eventReference, eventDecl?.name);
 
     return eventReferenceToPatternDocument(
       eventReference,
@@ -803,7 +803,7 @@ export const synthesizeEventPattern = (
     if (leftExpr !== undefined && rightExpr !== undefined) {
       throw new Error("Expected exactly one event reference, got two.");
     } else if (leftExpr !== undefined) {
-      assertValidEventRefererence(leftExpr, eventDecl?.name);
+      assertValidEventReference(leftExpr, eventDecl?.name);
       return {
         eventReference: leftExpr,
         eventExpr: left as PropAccessExpr | ElementAccessExpr,
@@ -811,7 +811,7 @@ export const synthesizeEventPattern = (
         op,
       };
     } else if (rightExpr !== undefined) {
-      assertValidEventRefererence(rightExpr, eventDecl?.name);
+      assertValidEventReference(rightExpr, eventDecl?.name);
       return {
         eventReference: rightExpr,
         eventExpr: right as PropAccessExpr | ElementAccessExpr,

--- a/src/event-bridge/rule.ts
+++ b/src/event-bridge/rule.ts
@@ -11,7 +11,9 @@ import {
   EventBusTargetResource,
   LambdaTargetProps,
   pipe,
+  StateMachineTargetProps,
 } from "./target";
+import { ExpressStepFunction, StepFunction } from "../step-function";
 
 /**
  * A function interface used by the {@link EventBus}'s when function to generate a rule.
@@ -77,7 +79,7 @@ export interface IEventBusRule<T extends EventBusRuleInput> {
    * ```
    *
    *
-   * Local varaibles
+   * Local variables
    *
    * ```ts
    * .map(event => {
@@ -136,6 +138,9 @@ export interface IEventBusRule<T extends EventBusRuleInput> {
   pipe(func: Function<T, any>): void;
   pipe(bus: EventBus<T>): void;
   pipe(props: EventBusTargetProps<T>): void;
+  pipe(props: StateMachineTargetProps<T>): void;
+  pipe(props: StepFunction<T, any>): void;
+  pipe(props: ExpressStepFunction<T, any>): void;
 }
 
 abstract class EventBusRuleBase<T extends EventBusRuleInput>
@@ -163,8 +168,11 @@ abstract class EventBusRuleBase<T extends EventBusRuleInput>
   pipe(func: Function<T, any>): void;
   pipe(bus: EventBus<T>): void;
   pipe(props: EventBusTargetProps<T>): void;
+  pipe(props: StateMachineTargetProps<T>): void;
+  pipe(props: StepFunction<T, any>): void;
+  pipe(props: ExpressStepFunction<T, any>): void;
   pipe(resource: EventBusTargetResource<T, T>): void {
-    pipe(this, resource);
+    pipe(this, resource as any);
   }
 }
 

--- a/src/event-bridge/target-input.ts
+++ b/src/event-bridge/target-input.ts
@@ -17,7 +17,7 @@ import {
   ObjectLiteralExpr,
 } from "../expression";
 import {
-  assertValidEventRefererence,
+  assertValidEventReference,
   flattenReturnEvent,
   evalToConstant,
   getReferencePath,
@@ -115,7 +115,7 @@ export const synthesizeEventBridgeTargets = (
       isIdentifier(expr)
     ) {
       const ref = getReferencePath(expr);
-      assertValidEventRefererence(ref, eventDecl?.name, utilsDecl?.name);
+      assertValidEventReference(ref, eventDecl?.name, utilsDecl?.name);
       // If the event parameter is used directly, replace it with the predefined <aws.events.event> reference.
       if (
         eventDecl &&

--- a/src/event-bridge/target.ts
+++ b/src/event-bridge/target.ts
@@ -3,31 +3,63 @@ import { EventBus } from "./event-bus";
 import { Function, isFunction } from "../function";
 import { EventBusRuleInput } from "./types";
 import { IEventBusRule } from "./rule";
+import {
+  ExpressStepFunction,
+  isStepFunction,
+  StepFunction,
+} from "../step-function";
+import { assertNever } from "../assert";
 
 export type LambdaTargetProps<P> = {
   func: Function<P, any>;
 } & Omit<aws_events_targets.LambdaFunctionProps, "event">;
 
+const isLambdaTargetProps = <P>(props: any): props is LambdaTargetProps<P> => {
+  return "func" in props;
+};
+
 export type EventBusTargetProps<P extends EventBusRuleInput> = {
   bus: EventBus<P>;
 } & aws_events_targets.EventBusProps;
+
+const isEventBusTargetProps = <P extends EventBusRuleInput>(
+  props: any
+): props is EventBusTargetProps<P> => {
+  return "bus" in props;
+};
+
+export type StateMachineTargetProps<P extends Record<string, any> | undefined> =
+  {
+    machine: ExpressStepFunction<P, any> | StepFunction<P, any>;
+  } & Omit<aws_events_targets.SfnStateMachineProps, "input">;
+
+const isStateMachineTargetProps = <P>(
+  props: any
+): props is StateMachineTargetProps<P> => {
+  return "machine" in props;
+};
 
 export type EventBusTargetResource<T extends EventBusRuleInput, P> =
   | Function<P, any>
   | LambdaTargetProps<P>
   | EventBus<T>
-  | EventBusTargetProps<T>;
+  | EventBusTargetProps<T>
+  | ExpressStepFunction<P, any>
+  | StepFunction<P, any>
+  | StateMachineTargetProps<P>;
 
 /**
  * Add a target to the run based on the configuration given.
  */
-export const pipe = <T extends EventBusRuleInput, P>(
+export function pipe<T extends EventBusRuleInput, P>(
   rule: IEventBusRule<T>,
   resource: EventBusTargetResource<T, P>,
   targetInput?: aws_events.RuleTargetInput
-) => {
-  if (isFunction(resource) || "func" in resource) {
-    const _props = isFunction(resource) ? { func: resource } : resource;
+) {
+  if (isFunction<P, any>(resource) || isLambdaTargetProps<P>(resource)) {
+    const _props: LambdaTargetProps<P> = isFunction<P, any>(resource)
+      ? { func: resource }
+      : resource;
 
     return rule.rule.addTarget(
       new aws_events_targets.LambdaFunction(_props.func.resource, {
@@ -37,12 +69,16 @@ export const pipe = <T extends EventBusRuleInput, P>(
         event: targetInput,
       })
     );
-  } else if (resource instanceof EventBus || "bus" in resource) {
+  } else if (
+    resource instanceof EventBus ||
+    isEventBusTargetProps<T>(resource)
+  ) {
     if (targetInput) {
       throw new Error("Event bus rule target does not support target input.");
     }
 
-    const _props = resource instanceof EventBus ? { bus: resource } : resource;
+    const _props: EventBusTargetProps<T> =
+      resource instanceof EventBus ? { bus: resource } : resource;
 
     return rule.rule.addTarget(
       new aws_events_targets.EventBus(_props.bus.bus, {
@@ -50,5 +86,21 @@ export const pipe = <T extends EventBusRuleInput, P>(
         role: _props.role,
       })
     );
+  } else if (
+    isStepFunction<P>(resource) ||
+    isStateMachineTargetProps<P>(resource)
+  ) {
+    const _props: StateMachineTargetProps<any> = isStepFunction<P>(resource)
+      ? { machine: resource }
+      : resource;
+
+    return rule.rule.addTarget(
+      new aws_events_targets.SfnStateMachine(_props.machine, {
+        ..._props,
+        input: targetInput,
+      })
+    );
   }
-};
+
+  assertNever(resource);
+}

--- a/src/event-bridge/transform.ts
+++ b/src/event-bridge/transform.ts
@@ -2,15 +2,16 @@ import { aws_events } from "aws-cdk-lib";
 import { FunctionDecl } from "../declaration";
 import { synthesizeEventBridgeTargets } from "./target-input";
 import { Function } from "../function";
-import { LambdaTargetProps, pipe } from "./target";
+import { LambdaTargetProps, pipe, StateMachineTargetProps } from "./target";
 import { EventBusRuleInput } from "./types";
 import { IEventBusRule } from "./rule";
+import { StepFunction, ExpressStepFunction } from "../step-function";
 
 /**
  * A function interface used by the {@link EventBusRule}'s map function.
  *
  * event is the event matched by the rule. This argument is optional.
- * $utils is a collection of built-in utilities wrapping EventBridge TargetInputs like contextual constants avaliable to the transformer.
+ * $utils is a collection of built-in utilities wrapping EventBridge TargetInputs like contextual constants available to the transformer.
  */
 export type EventTransformFunction<E extends EventBusRuleInput, O = any> = (
   event: E,
@@ -60,7 +61,17 @@ export class EventBusTransform<T extends EventBusRuleInput, P> {
    */
   pipe<P>(props: LambdaTargetProps<P>): void;
   pipe<P>(func: Function<P, any>): void;
-  pipe<P>(resource: Function<P, any> | LambdaTargetProps<P>): void {
-    pipe(this.rule, resource, this.targetInput);
+  pipe<P>(props: StateMachineTargetProps<P>): void;
+  pipe<P>(props: StepFunction<P, any>): void;
+  pipe<P>(props: ExpressStepFunction<P, any>): void;
+  pipe<P>(
+    resource:
+      | Function<P, any>
+      | LambdaTargetProps<P>
+      | StateMachineTargetProps<P>
+      | StepFunction<P, any>
+      | ExpressStepFunction<P, any>
+  ): void {
+    pipe(this.rule, resource as any, this.targetInput);
   }
 }

--- a/src/event-bridge/utils.ts
+++ b/src/event-bridge/utils.ts
@@ -345,7 +345,7 @@ export type EventReference = ReferencePath & {
 };
 
 // TODO: validate again object schema?
-export function assertValidEventRefererence(
+export function assertValidEventReference(
   eventReference?: ReferencePath,
   eventName?: string,
   utilsName?: string

--- a/src/expression.ts
+++ b/src/expression.ts
@@ -23,7 +23,6 @@ export type Expr =
   | CallExpr
   | ConditionExpr
   | ComputedPropertyNameExpr
-  | FunctionExpr
   | ElementAccessExpr
   | FunctionExpr
   | Identifier

--- a/src/expression.ts
+++ b/src/expression.ts
@@ -122,7 +122,12 @@ export class FunctionExpr<
 
 export const isReferenceExpr = typeGuard("ReferenceExpr");
 
-export type CanReference = AnyTable | AnyLambda | AnyStepFunction | typeof $AWS;
+export type CanReference =
+  | AnyTable
+  | AnyLambda
+  | AnyStepFunction
+  | typeof $AWS
+  | unknown;
 
 export class ReferenceExpr extends BaseExpr<"ReferenceExpr"> {
   constructor(readonly name: string, readonly ref: () => CanReference) {
@@ -200,13 +205,13 @@ export class ElementAccessExpr extends BaseExpr<"ElementAccessExpr"> {
 export const isArgument = typeGuard("Argument");
 
 export class Argument extends BaseExpr<"Argument", CallExpr | NewExpr> {
-  constructor(readonly expr: Expr, readonly name?: string) {
+  constructor(readonly expr?: Expr, readonly name?: string) {
     super("Argument");
-    expr.setParent(this);
+    expr?.setParent(this);
   }
 
   public clone(): this {
-    return new Argument(this.expr.clone(), this.name) as this;
+    return new Argument(this.expr?.clone(), this.name) as this;
   }
 }
 
@@ -527,6 +532,8 @@ export const isTypeOfExpr = typeGuard("TypeOfExpr");
 export class TypeOfExpr extends BaseExpr<"TypeOfExpr"> {
   constructor(readonly expr: Expr) {
     super("TypeOfExpr");
+
+    expr.setParent(this);
   }
 
   public clone(): this {

--- a/src/function.ts
+++ b/src/function.ts
@@ -39,7 +39,9 @@ export class Function<P, O> {
       const payloadArg = call.getArgument("payload");
 
       if (isVTL(context)) {
-        const payload = payloadArg ? context.eval(payloadArg.expr) : "$null";
+        const payload = payloadArg?.expr
+          ? context.eval(payloadArg.expr)
+          : "$null";
 
         const request = context.var(
           `{"version": "2018-05-29", "operation": "Invoke", "payload": ${payload}}`
@@ -53,7 +55,9 @@ export class Function<P, O> {
           Parameters: {
             FunctionName: this.resource.functionName,
             [`Payload${
-              payloadArg && isVariableReference(payloadArg.expr) ? ".$" : ""
+              payloadArg?.expr && isVariableReference(payloadArg.expr)
+                ? ".$"
+                : ""
             }`]: payloadArg ? ASL.toJson(payloadArg.expr) : null,
           },
           ResultSelector: "$.Payload",

--- a/src/util.ts
+++ b/src/util.ts
@@ -145,12 +145,6 @@ export function hasParent(node: ts.Node, parent: ts.Node): boolean {
   return hasParent(node.parent, parent);
 }
 
-/**
- * An interface used to identify interfaces owned by Functionless.
- * Interfaces cannot have static members or decorators.
- */
-export interface __FunctionlessBase {}
-
 export type ConstantValue =
   | PrimitiveValue
   | { [key: string]: ConstantValue }

--- a/src/util.ts
+++ b/src/util.ts
@@ -2,6 +2,11 @@ import { CallExpr, CanReference } from "./expression";
 import { FunctionlessNode } from "./node";
 import { VTL } from "./vtl";
 import { ASL, Task } from "./asl";
+import { isAWS } from "./aws";
+import ts from "typescript";
+import { isTable } from "./table";
+import { isFunction } from "./function";
+import { isStepFunction } from "./step-function";
 
 export type AnyFunction = (...args: any[]) => any;
 
@@ -31,11 +36,12 @@ export function toName(expr: FunctionlessNode): string {
     return `${toName(expr.expr)}_${expr.name}`;
   } else if (expr.kind === "ReferenceExpr") {
     const ref = expr.ref();
-    if (ref.kind === "AWS") {
+    if (isAWS(ref)) {
       return "AWS";
-    } else {
+    } else if (isTable(ref) || isFunction(ref) || isStepFunction(ref)) {
       return ref.resource.node.addr;
     }
+    throw Error("Cannot derive a name from a external node.");
   } else {
     throw new Error(`invalid expression: '${expr.kind}'`);
   }
@@ -129,3 +135,35 @@ export function flatten<T>(arr: AnyDepthArray<T>): T[] {
     return [arr];
   }
 }
+
+export function hasParent(node: ts.Node, parent: ts.Node): boolean {
+  if (!node.parent) {
+    return false;
+  } else if (node.parent === parent) {
+    return true;
+  }
+  return hasParent(node.parent, parent);
+}
+
+/**
+ * An interface used to identify interfaces owned by Functionless.
+ * Interfaces cannot have static members or decorators.
+ */
+export interface __FunctionlessBase {}
+
+export type ConstantValue =
+  | PrimitiveValue
+  | { [key: string]: ConstantValue }
+  | ConstantValue[];
+
+export type PrimitiveValue = string | number | boolean | undefined | null;
+
+export const isPrimitive = (val: any): val is PrimitiveValue => {
+  return (
+    typeof val === "string" ||
+    typeof val === "number" ||
+    typeof val === "boolean" ||
+    typeof val === "undefined" ||
+    val === null
+  );
+};

--- a/src/visit.ts
+++ b/src/visit.ts
@@ -75,6 +75,9 @@ export function visitEachChild<T extends FunctionlessNode>(
   ) => FunctionlessNode | FunctionlessNode[] | undefined
 ): T {
   if (node.kind === "Argument") {
+    if (!node.expr) {
+      return node.clone() as T;
+    }
     const expr = visitor(node.expr);
     ensure(expr, isExpr, `an Argument's expr must be an Expr`);
     return new Argument(expr, node.name) as T;
@@ -140,6 +143,9 @@ export function visitEachChild<T extends FunctionlessNode>(
       `visitEachChild of a ${node.kind}'s expr must return a single Expr`
     );
     const args = node.args.flatMap((arg) => {
+      if (!arg.expr) {
+        return arg.clone();
+      }
       const expr = visitor(arg.expr);
       ensure(
         expr,

--- a/src/vtl.ts
+++ b/src/vtl.ts
@@ -123,9 +123,12 @@ export class VTL {
    * @param node the {@link Expr} or {@link Stmt} to evaluate.
    * @returns a variable reference to the evaluated value
    */
-  public eval(node: Expr, returnVar?: string): string;
+  public eval(node?: Expr, returnVar?: string): string;
   public eval(node: Stmt, returnVar?: string): void;
-  public eval(node: FunctionlessNode, returnVar?: string): string | void {
+  public eval(node?: FunctionlessNode, returnVar?: string): string | void {
+    if (!node) {
+      return "$null";
+    }
     switch (node.kind) {
       case "ArrayLiteralExpr": {
         if (

--- a/test-app/src/message-board.ts
+++ b/test-app/src/message-board.ts
@@ -208,7 +208,7 @@ export const addComment = new AppsyncResolver<
   });
 
   // kick off a workflow to validate the comment
-  commentValidationWorkflow(comment);
+  commentValidationWorkflow({ input: comment });
 
   return comment;
 }).addResolver(api, {
@@ -286,7 +286,7 @@ export const deletePost = new AppsyncResolver<
     return undefined;
   }
 
-  return deleteWorkflow({ postId: $context.arguments.postId });
+  return deleteWorkflow({ input: { postId: $context.arguments.postId } });
 }).addResolver(api, {
   typeName: "Mutation",
   fieldName: "deletePost",
@@ -390,6 +390,6 @@ defaultBus
   .pipe(sendNotification);
 
 defaultBus
-  .when(stack, 'testDelete', (event) => event.source === "test")
+  .when(stack, "testDelete", (event) => event.source === "test")
   .map((event) => event.detail)
   .pipe(deleteWorkflow);

--- a/test-app/src/people-db.ts
+++ b/test-app/src/people-db.ts
@@ -115,7 +115,7 @@ export class PeopleDatabase extends Construct {
     >(($context) => {
       let person;
       // example of integrating with an Express Step Function from Appsync
-      person = this.getPersonMachine({ id: $context.arguments.id });
+      person = this.getPersonMachine({ input: { id: $context.arguments.id } });
 
       if (person.status === "SUCCEEDED") {
         return person.output;

--- a/test-app/src/people-db.ts
+++ b/test-app/src/people-db.ts
@@ -70,7 +70,10 @@ export class PeopleDatabase extends Construct {
     });
 
     // a synchronous Express Step Function for getting a Person
-    this.getPersonMachine = new ExpressStepFunction(
+    this.getPersonMachine = new ExpressStepFunction<
+      { id: string },
+      undefined | ProcessedPerson
+    >(
       this,
       "GetPersonMachine",
       {
@@ -79,12 +82,12 @@ export class PeopleDatabase extends Construct {
           level: aws_stepfunctions.LogLevel.ALL,
         },
       },
-      (id: string) => {
+      (input) => {
         const person = $AWS.DynamoDB.GetItem({
           TableName: this.personTable,
           Key: {
             id: {
-              S: id,
+              S: input.id,
             },
           },
         });
@@ -112,7 +115,7 @@ export class PeopleDatabase extends Construct {
     >(($context) => {
       let person;
       // example of integrating with an Express Step Function from Appsync
-      person = this.getPersonMachine($context.arguments.id);
+      person = this.getPersonMachine({ id: $context.arguments.id });
 
       if (person.status === "SUCCEEDED") {
         return person.output;

--- a/test/appsync.test.ts
+++ b/test/appsync.test.ts
@@ -1,0 +1,293 @@
+import { Stack } from "aws-cdk-lib";
+import { AppsyncResolver, reflect, StepFunction } from "../src";
+import { VTL } from "../src/vtl";
+import {
+  appsyncTestCase,
+  appsyncVelocityJsonTestCase,
+  getAppSyncTemplates,
+} from "./util";
+
+describe("step function integration", () => {
+  let stack: Stack;
+  beforeEach(() => {
+    stack = new Stack();
+  });
+  test("machine with no parameters", () => {
+    const machine = new StepFunction(stack, "machine", () => {});
+
+    const func = reflect(() => {
+      machine({});
+    });
+
+    appsyncTestCase(
+      func,
+      "{}",
+      `${VTL.CircuitBreaker}
+#set($v1 = {})
+$util.qr($v1.put('stateMachineArn', '${machine.stateMachineArn}'))
+{
+  "version": "2018-05-29",
+  "method": "POST",
+  "resourcePath": "/",
+  "params": {
+    "headers": {
+      "content-type": "application/x-amz-json-1.0",
+      "x-amz-target": "AWSStepFunctions.StartExecution"
+    },
+    "body": $util.toJson($v1)
+  }
+}`,
+      "{}",
+      VTL.CircuitBreaker
+    );
+
+    const templates = getAppSyncTemplates(func);
+
+    appsyncVelocityJsonTestCase(
+      templates[1],
+      { arguments: {}, source: {} },
+      {
+        result: {
+          version: "2018-05-29",
+          method: "POST",
+          resourcePath: "/",
+          params: {
+            headers: {
+              "content-type": "application/x-amz-json-1.0",
+              "x-amz-target": "AWSStepFunctions.StartExecution",
+            },
+            body: {
+              stateMachineArn: machine.stateMachineArn,
+            },
+          },
+        },
+      }
+    );
+  });
+
+  test("machine with static parameters", () => {
+    const machine = new StepFunction<{ id: string }, void>(
+      stack,
+      "machine",
+      () => {}
+    );
+
+    const templates = getAppSyncTemplates(
+      reflect(() => {
+        machine({ input: { id: "1" } });
+      })
+    );
+
+    appsyncVelocityJsonTestCase(
+      templates[1],
+      { arguments: {}, source: {} },
+      {
+        result: {
+          version: "2018-05-29",
+          method: "POST",
+          resourcePath: "/",
+          params: {
+            headers: {
+              "content-type": "application/x-amz-json-1.0",
+              "x-amz-target": "AWSStepFunctions.StartExecution",
+            },
+            body: {
+              stateMachineArn: machine.stateMachineArn,
+              input: JSON.stringify({ id: "1" }),
+            },
+          },
+        },
+      }
+    );
+  });
+
+  test("machine with dynamic parameters", () => {
+    const machine = new StepFunction<{ id: string }, void>(
+      stack,
+      "machine",
+      () => {}
+    );
+
+    const templates = getAppSyncTemplates(
+      reflect((context) => {
+        machine({ input: { id: context.arguments.id } });
+      })
+    );
+
+    appsyncVelocityJsonTestCase(
+      templates[1],
+      { arguments: { id: "1" }, source: {} },
+      {
+        result: {
+          version: "2018-05-29",
+          method: "POST",
+          resourcePath: "/",
+          params: {
+            headers: {
+              "content-type": "application/x-amz-json-1.0",
+              "x-amz-target": "AWSStepFunctions.StartExecution",
+            },
+            body: {
+              stateMachineArn: machine.stateMachineArn,
+              input: JSON.stringify({ id: "1" }),
+            },
+          },
+        },
+      }
+    );
+  });
+
+  test("machine with name", () => {
+    const machine = new StepFunction(stack, "machine", () => {});
+
+    const templates = getAppSyncTemplates(
+      reflect((context) => {
+        machine({ name: context.arguments.id });
+      })
+    );
+
+    appsyncVelocityJsonTestCase(
+      templates[1],
+      { arguments: { id: "1" }, source: {} },
+      {
+        result: {
+          version: "2018-05-29",
+          method: "POST",
+          resourcePath: "/",
+          params: {
+            headers: {
+              "content-type": "application/x-amz-json-1.0",
+              "x-amz-target": "AWSStepFunctions.StartExecution",
+            },
+            body: {
+              stateMachineArn: machine.stateMachineArn,
+              name: "1",
+            },
+          },
+        },
+      }
+    );
+  });
+
+  test("machine with trace header", () => {
+    const machine = new StepFunction(stack, "machine", () => {});
+    new AppsyncResolver<{ id: string }, void>((context) => {
+      machine({ traceHeader: context.arguments.id });
+    });
+  });
+
+  test("machine describe exec", () => {
+    const machine = new StepFunction(stack, "machine", () => {});
+
+    const func = reflect(() => {
+      const exec = "exec1";
+      machine.describeExecution(exec);
+    });
+
+    appsyncTestCase(
+      func,
+      "{}",
+      `${VTL.CircuitBreaker}
+#set($context.stash.exec = 'exec1')
+{
+  "version": "2018-05-29",
+  "method": "POST",
+  "resourcePath": "/",
+  "params": {
+    "headers": {
+      "content-type": "application/x-amz-json-1.0",
+      "x-amz-target": "AWSStepFunctions.DescribeExecution"
+    },
+    "body": {
+      "executionArn": $util.toJson($context.stash.exec)
+    }
+  }
+}`,
+      "{}",
+      VTL.CircuitBreaker
+    );
+
+    const templates = getAppSyncTemplates(func);
+
+    appsyncVelocityJsonTestCase(
+      templates[1],
+      { arguments: {}, source: {} },
+      {
+        result: {
+          version: "2018-05-29",
+          method: "POST",
+          resourcePath: "/",
+          params: {
+            headers: {
+              "content-type": "application/x-amz-json-1.0",
+              "x-amz-target": "AWSStepFunctions.DescribeExecution",
+            },
+            body: {
+              executionArn: "exec1",
+            },
+          },
+        },
+      }
+    );
+  });
+
+  test("machine describe exec string", () => {
+    const machine = new StepFunction(stack, "machine", () => {});
+
+    const func = reflect(() => {
+      machine.describeExecution("exec1");
+    });
+
+    appsyncTestCase(
+      func,
+      "{}",
+      `${VTL.CircuitBreaker}
+{
+  "version": "2018-05-29",
+  "method": "POST",
+  "resourcePath": "/",
+  "params": {
+    "headers": {
+      "content-type": "application/x-amz-json-1.0",
+      "x-amz-target": "AWSStepFunctions.DescribeExecution"
+    },
+    "body": {
+      "executionArn": $util.toJson('exec1')
+    }
+  }
+}`,
+      "{}",
+      VTL.CircuitBreaker
+    );
+
+    const templates = getAppSyncTemplates(func);
+
+    appsyncVelocityJsonTestCase(
+      templates[1],
+      { arguments: {}, source: {} },
+      {
+        result: {
+          version: "2018-05-29",
+          method: "POST",
+          resourcePath: "/",
+          params: {
+            headers: {
+              "content-type": "application/x-amz-json-1.0",
+              "x-amz-target": "AWSStepFunctions.DescribeExecution",
+            },
+            body: {
+              executionArn: "exec1",
+            },
+          },
+        },
+      }
+    );
+  });
+
+  test("machine with trace header", () => {
+    const machine = new StepFunction(stack, "machine", () => {});
+    new AppsyncResolver<{ id: string }, void>((context) => {
+      machine({ traceHeader: context.arguments.id });
+    });
+  });
+});

--- a/test/eventpattern.test.ts
+++ b/test/eventpattern.test.ts
@@ -569,13 +569,26 @@ describe("event pattern", () => {
 
   describe("references", () => {
     const myConstant = "hello";
-    test.skip("external constant", () => {
+    test("external constant", () => {
       ebEventPatternTestCase(
         reflect<EventPredicateFunction<TestEvent>>(
           (event) => event.detail.str === myConstant
         ),
         {
           detail: { str: [myConstant] },
+        }
+      );
+    });
+
+    const constantObj = { value: "hello2" };
+
+    test("external constant", () => {
+      ebEventPatternTestCase(
+        reflect<EventPredicateFunction<TestEvent>>(
+          (event) => event.detail.str === constantObj.value
+        ),
+        {
+          detail: { str: [constantObj.value] },
         }
       );
     });
@@ -1513,5 +1526,93 @@ describe("event pattern", () => {
         "Expected exactly one event reference, got two."
       );
     });
+  });
+});
+
+// https://github.com/sam-goodwin/functionless/issues/68
+describe.skip("destructure", () => {
+  test("descture parameter", () => {
+    ebEventPatternTestCase(
+      reflect<EventPredicateFunction<TestEvent>>(
+        ({ source }) => source === "lambda"
+      ),
+      {
+        source: ["lambda"],
+      }
+    );
+  });
+
+  test("descture variable", () => {
+    ebEventPatternTestCase(
+      reflect<EventPredicateFunction<TestEvent>>((event) => {
+        const { source } = event;
+        return source === "lambda";
+      }),
+      {
+        source: ["lambda"],
+      }
+    );
+  });
+
+  test("descture multi-layer variable", () => {
+    ebEventPatternTestCase(
+      reflect<EventPredicateFunction<TestEvent>>((event) => {
+        const {
+          detail: { str },
+        } = event;
+        return str === "lambda";
+      }),
+      {
+        detail: { str: ["lambda"] },
+      }
+    );
+  });
+
+  test("descture array doesn't work", () => {
+    ebEventPatternTestCaseError(
+      reflect<EventPredicateFunction<TestEvent>>((event) => {
+        const {
+          detail: {
+            array: [value],
+          },
+        } = event;
+        return value === "lambda";
+      })
+    );
+  });
+
+  test("descture parameter array doesn't work", () => {
+    ebEventPatternTestCaseError(
+      reflect<EventPredicateFunction<TestEvent>>(
+        ({
+          detail: {
+            array: [value],
+          },
+        }) => value === "lambda"
+      )
+    );
+  });
+
+  test("descture variable rename", () => {
+    ebEventPatternTestCase(
+      reflect<EventPredicateFunction<TestEvent>>((event) => {
+        const { source: src } = event;
+        return src === "lambda";
+      }),
+      {
+        source: ["lambda"],
+      }
+    );
+  });
+
+  test("descture parameter rename", () => {
+    ebEventPatternTestCase(
+      reflect<EventPredicateFunction<TestEvent>>(
+        ({ source: src }) => src === "lambda"
+      ),
+      {
+        source: ["lambda"],
+      }
+    );
   });
 });

--- a/test/reflect.test.ts
+++ b/test/reflect.test.ts
@@ -125,7 +125,7 @@ test("named function args", () => {
   const expr = assertNodeKind<ExprStmt>(result.body.statements[0], "ExprStmt");
   const call = assertNodeKind<CallExpr>(expr.expr, "CallExpr");
 
-  expect(call.getArgument("searchString")?.expr.kind).toEqual(
+  expect(call.getArgument("searchString")?.expr?.kind).toEqual(
     "StringLiteralExpr"
   );
 });

--- a/test/step-function.test.ts
+++ b/test/step-function.test.ts
@@ -25,14 +25,18 @@ test("empty function", () => {
 
 test("return identifier", () => {
   const { stack } = initStepFunctionApp();
-  const definition = new ExpressStepFunction(stack, "fn", (id: string) => {
-    return id;
-  }).definition;
+  const definition = new ExpressStepFunction<{ id: string }, string>(
+    stack,
+    "fn",
+    (input) => {
+      return input.id;
+    }
+  ).definition;
 
   const expected: StateMachine<States> = {
-    StartAt: "return id",
+    StartAt: "return input.id",
     States: {
-      "return id": {
+      "return input.id": {
         Type: "Pass",
         End: true,
         OutputPath: "$.id",
@@ -44,18 +48,18 @@ test("return identifier", () => {
 
 test("return PropAccessExpr", () => {
   const { stack } = initStepFunctionApp();
-  const definition = new ExpressStepFunction(
+  const definition = new ExpressStepFunction<{ input: { id: string } }, string>(
     stack,
     "fn",
-    (input: { id: string }) => {
-      return input.id;
+    (input) => {
+      return input.input.id;
     }
   ).definition;
 
   const expected: StateMachine<States> = {
-    StartAt: "return input.id",
+    StartAt: "return input.input.id",
     States: {
-      "return input.id": {
+      "return input.input.id": {
         Type: "Pass",
         End: true,
         OutputPath: "$.input.id",
@@ -67,18 +71,17 @@ test("return PropAccessExpr", () => {
 
 test("return optional PropAccessExpr", () => {
   const { stack } = initStepFunctionApp();
-  const definition = new ExpressStepFunction(
-    stack,
-    "fn",
-    (input: { id?: string }) => {
-      return input?.id;
-    }
-  ).definition;
+  const definition = new ExpressStepFunction<
+    { input: { id?: string } },
+    string | undefined
+  >(stack, "fn", (input) => {
+    return input.input?.id;
+  }).definition;
 
   const expected: StateMachine<States> = {
-    StartAt: "return input.id",
+    StartAt: "return input.input.id",
     States: {
-      "return input.id": {
+      "return input.input.id": {
         Type: "Pass",
         End: true,
         // this can cause an error in Step Functions
@@ -97,14 +100,18 @@ test("return optional PropAccessExpr", () => {
 
 test("return items.slice(1)", () => {
   const { stack } = initStepFunctionApp();
-  const definition = new ExpressStepFunction(stack, "fn", (items: string[]) => {
-    return items.slice(1);
-  }).definition;
+  const definition = new ExpressStepFunction<{ items: string[] }, string[]>(
+    stack,
+    "fn",
+    (input) => {
+      return input.items.slice(1);
+    }
+  ).definition;
 
   expect(definition).toEqual({
-    StartAt: "return items.slice(1, undefined)",
+    StartAt: "return input.items.slice(1)",
     States: {
-      "return items.slice(1, undefined)": {
+      "return input.items.slice(1)": {
         End: true,
         InputPath: "$.items[1:]",
         ResultPath: "$",
@@ -116,14 +123,18 @@ test("return items.slice(1)", () => {
 
 test("return items.slice(1, 3)", () => {
   const { stack } = initStepFunctionApp();
-  const definition = new ExpressStepFunction(stack, "fn", (items: string[]) => {
-    return items.slice(1, 3);
-  }).definition;
+  const definition = new ExpressStepFunction<{ items: string[] }, string[]>(
+    stack,
+    "fn",
+    (input) => {
+      return input.items.slice(1, 3);
+    }
+  ).definition;
 
   expect(definition).toEqual({
-    StartAt: "return items.slice(1, 3)",
+    StartAt: "return input.items.slice(1, 3)",
     States: {
-      "return items.slice(1, 3)": {
+      "return input.items.slice(1, 3)": {
         End: true,
         InputPath: "$.items[1:3]",
         ResultPath: "$",
@@ -135,14 +146,17 @@ test("return items.slice(1, 3)", () => {
 
 test("return task({key: items.slice(1, 3)})", () => {
   const { stack, task } = initStepFunctionApp();
-  const definition = new ExpressStepFunction(stack, "fn", (items: string[]) => {
-    return task({ key: items.slice(1, 3) });
+  const definition = new ExpressStepFunction<
+    { items: string[] },
+    number | null
+  >(stack, "fn", (input) => {
+    return task({ key: input.items.slice(1, 3) });
   }).definition;
 
   expect(definition).toEqual({
-    StartAt: "return task({key: items.slice(1, 3)})",
+    StartAt: "return task({key: input.items.slice(1, 3)})",
     States: {
-      "return task({key: items.slice(1, 3)})": {
+      "return task({key: input.items.slice(1, 3)})": {
         Type: "Task",
         End: true,
         Resource: "arn:aws:states:::lambda:invoke",
@@ -294,16 +308,20 @@ test("return void", () => {
 
 test("conditionally return void", () => {
   const { stack } = initStepFunctionApp();
-  const definition = new ExpressStepFunction(stack, "fn", (id: string) => {
-    if (id === "hello") {
-      return;
+  const definition = new ExpressStepFunction<{ id: string }, void>(
+    stack,
+    "fn",
+    (input) => {
+      if (input.id === "hello") {
+        return;
+      }
     }
-  }).definition;
+  ).definition;
 
   expect(definition).toEqual({
-    StartAt: 'if(id == "hello")',
+    StartAt: 'if(input.id == "hello")',
     States: {
-      'if(id == "hello")': {
+      'if(input.id == "hello")': {
         Choices: [
           {
             Next: "return null",
@@ -336,18 +354,22 @@ test("conditionally return void", () => {
 
 test("if-else", () => {
   const { stack } = initStepFunctionApp();
-  const definition = new ExpressStepFunction(stack, "fn", (id: string) => {
-    if (id === "hello") {
-      return "hello";
-    } else {
-      return "world";
+  const definition = new ExpressStepFunction<{ id: string }, string>(
+    stack,
+    "fn",
+    (input) => {
+      if (input.id === "hello") {
+        return "hello";
+      } else {
+        return "world";
+      }
     }
-  }).definition;
+  ).definition;
 
   expect(definition).toEqual({
-    StartAt: 'if(id == "hello")',
+    StartAt: 'if(input.id == "hello")',
     States: {
-      'if(id == "hello")': {
+      'if(input.id == "hello")': {
         Choices: [
           {
             Next: 'return "hello"',
@@ -376,27 +398,31 @@ test("if-else", () => {
 
 test("if (typeof x === ??)", () => {
   const { stack } = initStepFunctionApp();
-  const definition = new ExpressStepFunction(stack, "fn", (id: any) => {
-    if (id === undefined) {
-      return "null";
-    } else if (typeof id === "undefined") {
-      return "undefined";
-    } else if (typeof id === "string") {
-      return "string";
-    } else if (typeof id === "boolean") {
-      return "boolean";
-    } else if (typeof id === "number") {
-      return "number";
-    } else if (typeof id === "bigint") {
-      return "bigint";
+  const definition = new ExpressStepFunction<{ id: string }, string | null>(
+    stack,
+    "fn",
+    (input) => {
+      if (input.id === undefined) {
+        return "null";
+      } else if (typeof input.id === "undefined") {
+        return "undefined";
+      } else if (typeof input.id === "string") {
+        return "string";
+      } else if (typeof input.id === "boolean") {
+        return "boolean";
+      } else if (typeof input.id === "number") {
+        return "number";
+      } else if (typeof input.id === "bigint") {
+        return "bigint";
+      }
+      return null;
     }
-    return null;
-  }).definition;
+  ).definition;
 
   expect(definition).toEqual({
-    StartAt: "if(id == undefined)",
+    StartAt: "if(input.id == undefined)",
     States: {
-      "if(id == undefined)": {
+      "if(input.id == undefined)": {
         Choices: [
           {
             Next: 'return "null"',
@@ -522,27 +548,31 @@ test("if (typeof x === ??)", () => {
 
 test("if (typeof x !== ??)", () => {
   const { stack } = initStepFunctionApp();
-  const definition = new ExpressStepFunction(stack, "fn", (id: any) => {
-    if (id !== undefined) {
-      return "null";
-    } else if (typeof id !== "undefined") {
-      return "undefined";
-    } else if (typeof id !== "string") {
-      return "string";
-    } else if (typeof id !== "boolean") {
-      return "boolean";
-    } else if (typeof id !== "number") {
-      return "number";
-    } else if (typeof id !== "bigint") {
-      return "bigint";
+  const definition = new ExpressStepFunction<{ id: any }, string | null>(
+    stack,
+    "fn",
+    (input) => {
+      if (input.id !== undefined) {
+        return "null";
+      } else if ("undefined" !== typeof input.id) {
+        return "undefined";
+      } else if (typeof input.id !== "string") {
+        return "string";
+      } else if (typeof input.id !== "boolean") {
+        return "boolean";
+      } else if (typeof input.id !== "number") {
+        return "number";
+      } else if (typeof input.id !== "bigint") {
+        return "bigint";
+      }
+      return null;
     }
-    return null;
-  }).definition;
+  ).definition;
 
   expect(definition).toEqual({
-    StartAt: "if(id != undefined)",
+    StartAt: "if(input.id != undefined)",
     States: {
-      "if(id != undefined)": {
+      "if(input.id != undefined)": {
         Choices: [
           {
             And: [
@@ -668,22 +698,23 @@ test("if (typeof x !== ??)", () => {
 
 test("if-else-if", () => {
   const { stack } = initStepFunctionApp();
-  const definition = new ExpressStepFunction(
+  const definition = new ExpressStepFunction<{ id: string }, string | void>(
     stack,
     "fn",
-    (id: string): string | void => {
-      if (id === "hello") {
+    (input) => {
+      if (input.id === "hello") {
         return "hello";
-      } else if (id === "world") {
+      } else if (input.id === "world") {
         return "world";
       }
+      return;
     }
   ).definition;
 
   expect(definition).toEqual({
-    StartAt: 'if(id == "hello")',
+    StartAt: 'if(input.id == "hello")',
     States: {
-      'if(id == "hello")': {
+      'if(input.id == "hello")': {
         Choices: [
           {
             Next: 'return "hello"',
@@ -725,17 +756,21 @@ test("if-else-if", () => {
 
 test("for-loop and do nothing", () => {
   const { stack } = initStepFunctionApp();
-  const definition = new ExpressStepFunction(stack, "fn", (items: string[]) => {
-    for (const item of items) {
-      // @ts-ignore
-      const a = item;
+  const definition = new ExpressStepFunction<{ items: string[] }, void>(
+    stack,
+    "fn",
+    (input) => {
+      for (const item of input.items) {
+        // @ts-ignore
+        const a = item;
+      }
     }
-  }).definition;
+  ).definition;
 
   const expected: StateMachine<States> = {
-    StartAt: "for(item of items)",
+    StartAt: "for(item of input.items)",
     States: {
-      "for(item of items)": {
+      "for(item of input.items)": {
         ItemsPath: "$.items",
         Iterator: {
           StartAt: "a = item",
@@ -774,17 +809,21 @@ test("for-loop and do nothing", () => {
 
 test("for i in items, items[i]", () => {
   const { stack } = initStepFunctionApp();
-  const definition = new ExpressStepFunction(stack, "fn", (items: string[]) => {
-    for (const i in items) {
-      // @ts-ignore
-      const a = items[i];
+  const definition = new ExpressStepFunction<{ items: string[] }, void>(
+    stack,
+    "fn",
+    (input) => {
+      for (const i in input.items) {
+        // @ts-ignore
+        const a = items[i];
+      }
     }
-  }).definition;
+  ).definition;
 
   expect(definition).toEqual({
-    StartAt: "for(i in items)",
+    StartAt: "for(i in input.items)",
     States: {
-      "for(i in items)": {
+      "for(i in input.items)": {
         ItemsPath: "$.items",
         Iterator: {
           StartAt: "a = items[i]",
@@ -824,18 +863,17 @@ test("for i in items, items[i]", () => {
 
 test("return a single Lambda Function call", () => {
   const { stack, getPerson } = initStepFunctionApp();
-  const definition = new ExpressStepFunction(
-    stack,
-    "fn",
-    (id: string): Person | undefined => {
-      return getPerson({ id });
-    }
-  ).definition;
+  const definition = new ExpressStepFunction<
+    { id: string },
+    Person | undefined
+  >(stack, "fn", (input) => {
+    return getPerson({ id: input.id });
+  }).definition;
 
   expect(definition).toEqual({
-    StartAt: "return getPerson({id: id})",
+    StartAt: "return getPerson({id: input.id})",
     States: {
-      "return getPerson({id: id})": {
+      "return getPerson({id: input.id})": {
         Type: "Task",
         Resource: "arn:aws:states:::lambda:invoke",
         End: true,
@@ -854,19 +892,18 @@ test("return a single Lambda Function call", () => {
 
 test("call Lambda Function, store as variable, return variable", () => {
   const { stack, getPerson } = initStepFunctionApp();
-  const definition = new ExpressStepFunction(
-    stack,
-    "fn",
-    (id: string): Person | undefined => {
-      const person = getPerson({ id });
-      return person;
-    }
-  ).definition;
+  const definition = new ExpressStepFunction<
+    { id: string },
+    Person | undefined
+  >(stack, "fn", (input) => {
+    const person = getPerson({ id: input.id });
+    return person;
+  }).definition;
 
   expect(definition).toEqual({
-    StartAt: "person = getPerson({id: id})",
+    StartAt: "person = getPerson({id: input.id})",
     States: {
-      "person = getPerson({id: id})": {
+      "person = getPerson({id: input.id})": {
         Type: "Task",
         Resource: "arn:aws:states:::lambda:invoke",
         ResultPath: "$.person",
@@ -890,35 +927,34 @@ test("call Lambda Function, store as variable, return variable", () => {
 
 test("return AWS.DynamoDB.GetItem", () => {
   const { stack, personTable } = initStepFunctionApp();
-  const definition = new ExpressStepFunction(
-    stack,
-    "fn",
-    (id: string): Person | undefined => {
-      const person = $AWS.DynamoDB.GetItem({
-        TableName: personTable,
-        Key: {
-          id: {
-            S: id,
-          },
+  const definition = new ExpressStepFunction<
+    { id: string },
+    Person | undefined
+  >(stack, "fn", (input) => {
+    const person = $AWS.DynamoDB.GetItem({
+      TableName: personTable,
+      Key: {
+        id: {
+          S: input.id,
         },
-      });
+      },
+    });
 
-      if (person.Item === undefined) {
-        return undefined;
-      }
-
-      return {
-        id: person.Item.id.S,
-        name: person.Item.name.S,
-      };
+    if (person.Item === undefined) {
+      return undefined;
     }
-  ).definition;
+
+    return {
+      id: person.Item.id.S,
+      name: person.Item.name.S,
+    };
+  }).definition;
 
   const expected: StateMachine<States> = {
     StartAt:
-      "person = $AWS.DynamoDB.GetItem({TableName: personTable, Key: {id: {S: id}}}",
+      "person = $AWS.DynamoDB.GetItem({TableName: personTable, Key: {id: {S: input",
     States: {
-      "person = $AWS.DynamoDB.GetItem({TableName: personTable, Key: {id: {S: id}}}":
+      "person = $AWS.DynamoDB.GetItem({TableName: personTable, Key: {id: {S: input":
         {
           Next: "if(person.Item == undefined)",
           ResultPath: "$.person",
@@ -977,41 +1013,40 @@ test("return AWS.DynamoDB.GetItem", () => {
 
 test("call AWS.DynamoDB.GetItem, then Lambda and return LiteralExpr", () => {
   const { stack, personTable, computeScore } = initStepFunctionApp();
-  const definition = new ExpressStepFunction(
-    stack,
-    "fn",
-    (id: string): (Person & { score: number }) | undefined => {
-      const person = $AWS.DynamoDB.GetItem({
-        TableName: personTable,
-        Key: {
-          id: {
-            S: id,
-          },
+  const definition = new ExpressStepFunction<
+    { id: string },
+    (Person & { score: number }) | undefined
+  >(stack, "fn", (input) => {
+    const person = $AWS.DynamoDB.GetItem({
+      TableName: personTable,
+      Key: {
+        id: {
+          S: input.id,
         },
-      });
+      },
+    });
 
-      if (person.Item === undefined) {
-        return undefined;
-      }
-
-      const score = computeScore({
-        id: person.Item.id.S,
-        name: person.Item.name.S,
-      });
-
-      return {
-        id: person.Item.id.S,
-        name: person.Item.name.S,
-        score,
-      };
+    if (person.Item === undefined) {
+      return undefined;
     }
-  ).definition;
+
+    const score = computeScore({
+      id: person.Item.id.S,
+      name: person.Item.name.S,
+    });
+
+    return {
+      id: person.Item.id.S,
+      name: person.Item.name.S,
+      score,
+    };
+  }).definition;
 
   const expected: StateMachine<States> = {
     StartAt:
-      "person = $AWS.DynamoDB.GetItem({TableName: personTable, Key: {id: {S: id}}}",
+      "person = $AWS.DynamoDB.GetItem({TableName: personTable, Key: {id: {S: input",
     States: {
-      "person = $AWS.DynamoDB.GetItem({TableName: personTable, Key: {id: {S: id}}}":
+      "person = $AWS.DynamoDB.GetItem({TableName: personTable, Key: {id: {S: input":
         {
           Next: "if(person.Item == undefined)",
           ResultPath: "$.person",
@@ -1086,14 +1121,14 @@ test("call AWS.DynamoDB.GetItem, then Lambda and return LiteralExpr", () => {
 
 test("for-loop over a list literal", () => {
   const { stack, computeScore } = initStepFunctionApp();
-  const definition = new ExpressStepFunction(
+  const definition = new ExpressStepFunction<{ id: string }, void>(
     stack,
     "fn",
-    (id: string): void => {
+    (input) => {
       const people = ["sam", "brendan"];
       for (const name of people) {
         computeScore({
-          id,
+          id: input.id,
           name,
         });
       }
@@ -1119,9 +1154,9 @@ test("for-loop over a list literal", () => {
           "name.$": "$$.Map.Item.Value",
         },
         Iterator: {
-          StartAt: "computeScore({id: id, name: name})",
+          StartAt: "computeScore({id: input.id, name: name})",
           States: {
-            "computeScore({id: id, name: name})": {
+            "computeScore({id: input.id, name: name})": {
               Type: "Task",
               ResultPath: null,
               End: true,
@@ -1153,16 +1188,16 @@ test("for-loop over a list literal", () => {
 
 test("conditionally call DynamoDB and then void", () => {
   const { stack, personTable } = initStepFunctionApp();
-  const definition = new ExpressStepFunction(
+  const definition = new ExpressStepFunction<{ id: string }, void>(
     stack,
     "fn",
-    (id: string): void => {
-      if (id === "hello") {
+    (input): void => {
+      if (input.id === "hello") {
         $AWS.DynamoDB.GetItem({
           TableName: personTable,
           Key: {
             id: {
-              S: id,
+              S: input.id,
             },
           },
         });
@@ -1171,12 +1206,12 @@ test("conditionally call DynamoDB and then void", () => {
   ).definition;
 
   const expected: StateMachine<States> = {
-    StartAt: 'if(id == "hello")',
+    StartAt: 'if(input.id == "hello")',
     States: {
-      'if(id == "hello")': {
+      'if(input.id == "hello")': {
         Choices: [
           {
-            Next: "$AWS.DynamoDB.GetItem({TableName: personTable, Key: {id: {S: id}}})",
+            Next: "$AWS.DynamoDB.GetItem({TableName: personTable, Key: {id: {S: input.id}}})",
             StringEquals: "hello",
             Variable: "$.id",
           },
@@ -1184,20 +1219,21 @@ test("conditionally call DynamoDB and then void", () => {
         Default: "return null",
         Type: "Choice",
       },
-      "$AWS.DynamoDB.GetItem({TableName: personTable, Key: {id: {S: id}}})": {
-        Next: "return null",
-        Parameters: {
-          Key: {
-            id: {
-              "S.$": "$.id",
+      "$AWS.DynamoDB.GetItem({TableName: personTable, Key: {id: {S: input.id}}})":
+        {
+          Next: "return null",
+          Parameters: {
+            Key: {
+              id: {
+                "S.$": "$.id",
+              },
             },
+            TableName: personTable.resource.tableName,
           },
-          TableName: personTable.resource.tableName,
+          Resource: "arn:aws:states:::aws-sdk:dynamodb:getItem",
+          ResultPath: null,
+          Type: "Task",
         },
-        Resource: "arn:aws:states:::aws-sdk:dynamodb:getItem",
-        ResultPath: null,
-        Type: "Task",
-      },
       "return null": {
         Type: "Pass",
         End: true,
@@ -1241,18 +1277,17 @@ test("waitFor literal number of seconds", () => {
 test("waitFor reference number of seconds", () => {
   const { stack } = initStepFunctionApp();
 
-  const definition = new ExpressStepFunction(
-    stack,
-    "fn",
-    (seconds: number): string | void => {
-      $SFN.waitFor(seconds);
-    }
-  ).definition;
+  const definition = new ExpressStepFunction<
+    { seconds: number },
+    string | void
+  >(stack, "fn", (input) => {
+    $SFN.waitFor(input.seconds);
+  }).definition;
 
   expect(definition).toEqual({
-    StartAt: "$SFN.waitFor(seconds)",
+    StartAt: "$SFN.waitFor(input.seconds)",
     States: {
-      "$SFN.waitFor(seconds)": {
+      "$SFN.waitFor(input.seconds)": {
         Next: "return null",
         SecondsPath: "$.seconds",
         Type: "Wait",
@@ -1298,18 +1333,18 @@ test("waitFor literal timestamp", () => {
 test("waitUntil reference timestamp", () => {
   const { stack } = initStepFunctionApp();
 
-  const definition = new ExpressStepFunction(
+  const definition = new ExpressStepFunction<{ until: string }, string | void>(
     stack,
     "fn",
-    (until: string): string | void => {
-      $SFN.waitUntil(until);
+    (input) => {
+      $SFN.waitUntil(input.until);
     }
   ).definition;
 
   expect(definition).toEqual({
-    StartAt: "$SFN.waitUntil(until)",
+    StartAt: "$SFN.waitUntil(input.until)",
     States: {
-      "$SFN.waitUntil(until)": {
+      "$SFN.waitUntil(input.until)": {
         Next: "return null",
         TimestampPath: "$.until",
         Type: "Wait",
@@ -1659,25 +1694,29 @@ test("try-catch with guaranteed throw new Error", () => {
 test("try-catch with optional throw of an Error", () => {
   const { stack } = initStepFunctionApp();
 
-  const definition = new ExpressStepFunction(stack, "fn", (id: string) => {
-    try {
-      if (id === "hello") {
-        throw new Error("cause");
-      }
-      return "hello world";
-    } catch (err: any) {
-      if (err.message === "cause") {
-        return "hello";
-      } else {
-        return "world";
+  const definition = new ExpressStepFunction<{ id: string }, void>(
+    stack,
+    "fn",
+    (input) => {
+      try {
+        if (input.id === "hello") {
+          throw new Error("cause");
+        }
+        return "hello world";
+      } catch (err: any) {
+        if (err.message === "cause") {
+          return "hello";
+        } else {
+          return "world";
+        }
       }
     }
-  }).definition;
+  ).definition;
 
   expect(definition).toEqual({
-    StartAt: 'if(id == "hello")',
+    StartAt: 'if(input.id == "hello")',
     States: {
-      'if(id == "hello")': {
+      'if(input.id == "hello")': {
         Choices: [
           {
             Next: 'throw new Error("cause")',
@@ -1732,31 +1771,35 @@ test("try-catch with optional throw of an Error", () => {
 test("try-catch with optional task", () => {
   const { stack, computeScore } = initStepFunctionApp();
 
-  const definition = new ExpressStepFunction(stack, "fn", (id: string) => {
-    try {
-      if (id === "hello") {
-        computeScore({
-          id,
-          name: "sam",
-        });
-      }
-      return "hello world";
-    } catch (err: any) {
-      if (err.message === "cause") {
-        return "hello";
-      } else {
-        return "world";
+  const definition = new ExpressStepFunction<{ id: string }, string>(
+    stack,
+    "fn",
+    (input) => {
+      try {
+        if (input.id === "hello") {
+          computeScore({
+            id: input.id,
+            name: "sam",
+          });
+        }
+        return "hello world";
+      } catch (err: any) {
+        if (err.message === "cause") {
+          return "hello";
+        } else {
+          return "world";
+        }
       }
     }
-  }).definition;
+  ).definition;
 
   expect(definition).toEqual({
-    StartAt: 'if(id == "hello")',
+    StartAt: 'if(input.id == "hello")',
     States: {
-      'if(id == "hello")': {
+      'if(input.id == "hello")': {
         Choices: [
           {
-            Next: 'computeScore({id: id, name: "sam"})',
+            Next: 'computeScore({id: input.id, name: "sam"})',
             StringEquals: "hello",
             Variable: "$.id",
           },
@@ -1764,7 +1807,7 @@ test("try-catch with optional task", () => {
         Default: 'return "hello world"',
         Type: "Choice",
       },
-      'computeScore({id: id, name: "sam"})': {
+      'computeScore({id: input.id, name: "sam"})': {
         Catch: [
           {
             ErrorEquals: ["States.ALL"],
@@ -1835,31 +1878,35 @@ test("try-catch with optional task", () => {
 test("try-catch with optional return of task", () => {
   const { stack, computeScore } = initStepFunctionApp();
 
-  const definition = new ExpressStepFunction(stack, "fn", (id: string) => {
-    try {
-      if (id === "hello") {
-        return computeScore({
-          id,
-          name: "sam",
-        });
-      }
-      return "hello world";
-    } catch (err: any) {
-      if (err.message === "cause") {
-        return "hello";
-      } else {
-        return "world";
+  const definition = new ExpressStepFunction<{ id: string }, string | number>(
+    stack,
+    "fn",
+    (input) => {
+      try {
+        if (input.id === "hello") {
+          return computeScore({
+            id: input.id,
+            name: "sam",
+          });
+        }
+        return "hello world";
+      } catch (err: any) {
+        if (err.message === "cause") {
+          return "hello";
+        } else {
+          return "world";
+        }
       }
     }
-  }).definition;
+  ).definition;
 
   expect(definition).toEqual({
-    StartAt: 'if(id == "hello")',
+    StartAt: 'if(input.id == "hello")',
     States: {
-      'if(id == "hello")': {
+      'if(input.id == "hello")': {
         Choices: [
           {
-            Next: 'return computeScore({id: id, name: "sam"})',
+            Next: 'return computeScore({id: input.id, name: "sam"})',
             StringEquals: "hello",
             Variable: "$.id",
           },
@@ -1867,7 +1914,7 @@ test("try-catch with optional return of task", () => {
         Default: 'return "hello world"',
         Type: "Choice",
       },
-      'return computeScore({id: id, name: "sam"})': {
+      'return computeScore({id: input.id, name: "sam"})': {
         Catch: [
           {
             ErrorEquals: ["States.ALL"],
@@ -1981,17 +2028,21 @@ test("nested try-catch", () => {
 test("throw in for-of", () => {
   const { stack } = initStepFunctionApp();
 
-  const definition = new ExpressStepFunction(stack, "fn", (items: string[]) => {
-    // @ts-ignore
-    for (const item of items) {
-      throw new Error("err");
+  const definition = new ExpressStepFunction<{ items: string[] }, void>(
+    stack,
+    "fn",
+    (input) => {
+      // @ts-ignore
+      for (const item of input.items) {
+        throw new Error("err");
+      }
     }
-  }).definition;
+  ).definition;
 
   expect(definition).toEqual({
-    StartAt: "for(item of items)",
+    StartAt: "for(item of input.items)",
     States: {
-      "for(item of items)": {
+      "for(item of input.items)": {
         ItemsPath: "$.items",
         Iterator: {
           StartAt: 'throw new Error("err")',
@@ -2026,25 +2077,24 @@ test("throw in for-of", () => {
 test("try-catch, no variable, contains for-of, throw", () => {
   const { stack } = initStepFunctionApp();
 
-  const definition = new ExpressStepFunction(
-    stack,
-    "fn",
-    (items: string[]): string | void => {
-      try {
-        // @ts-ignore
-        for (const item of items) {
-          throw new Error("err");
-        }
-      } catch {
-        return "hello";
+  const definition = new ExpressStepFunction<
+    { items: string[] },
+    string | void
+  >(stack, "fn", (input): string | void => {
+    try {
+      // @ts-ignore
+      for (const item of input.items) {
+        throw new Error("err");
       }
+    } catch {
+      return "hello";
     }
-  ).definition;
+  }).definition;
 
   expect(definition).toEqual({
-    StartAt: "for(item of items)",
+    StartAt: "for(item of input.items)",
     States: {
-      "for(item of items)": {
+      "for(item of input.items)": {
         Catch: [
           {
             ErrorEquals: ["States.ALL"],
@@ -2092,25 +2142,24 @@ test("try-catch, no variable, contains for-of, throw", () => {
 test("try-catch, err variable, contains for-of, throw", () => {
   const { stack } = initStepFunctionApp();
 
-  const definition = new ExpressStepFunction(
-    stack,
-    "fn",
-    (items: string[]): string | void => {
-      try {
-        // @ts-ignore
-        for (const item of items) {
-          throw new Error("err");
-        }
-      } catch (err: any) {
-        return err.message;
+  const definition = new ExpressStepFunction<
+    { items: string[] },
+    string | void
+  >(stack, "fn", (input): string | void => {
+    try {
+      // @ts-ignore
+      for (const item of input.items) {
+        throw new Error("err");
       }
+    } catch (err: any) {
+      return err.message;
     }
-  ).definition;
+  }).definition;
 
   expect(definition).toEqual({
-    StartAt: "for(item of items)",
+    StartAt: "for(item of input.items)",
     States: {
-      "for(item of items)": {
+      "for(item of input.items)": {
         Catch: [
           {
             ErrorEquals: ["States.ALL"],
@@ -2231,9 +2280,9 @@ test("try { task } catch { throw } finally { task() }", () => {
   }).definition;
 
   expect(definition).toEqual({
-    StartAt: "task(undefined)",
+    StartAt: "task()",
     States: {
-      "task(undefined)": {
+      "task()": {
         Catch: [
           {
             ErrorEquals: ["States.ALL"],
@@ -2245,7 +2294,7 @@ test("try { task } catch { throw } finally { task() }", () => {
         ResultSelector: "$.Payload",
         Parameters: {
           FunctionName: task.resource.functionName,
-          Payload: null,
+          Payload: undefined,
         },
         Resource: "arn:aws:states:::lambda:invoke",
         ResultPath: null,
@@ -2469,14 +2518,14 @@ test("try, throw, catch, throw, finally, return", () => {
 test("try { throw } catch { (maybe) throw } finally { task }", () => {
   const { stack, task } = initStepFunctionApp();
 
-  const definition = new ExpressStepFunction(
+  const definition = new ExpressStepFunction<{ id: string }, string | void>(
     stack,
     "fn",
-    (id: string): string | void => {
+    (input) => {
       try {
         throw new Error("go");
       } catch {
-        if (id === "sam") {
+        if (input.id === "sam") {
           throw new Error("little");
         }
       } finally {
@@ -2491,14 +2540,14 @@ test("try { throw } catch { (maybe) throw } finally { task }", () => {
     StartAt: 'throw new Error("go")',
     States: {
       'throw new Error("go")': {
-        Next: 'if(id == "sam")',
+        Next: 'if(input.id == "sam")',
         Result: {
           message: "go",
         },
         ResultPath: null,
         Type: "Pass",
       },
-      'if(id == "sam")': {
+      'if(input.id == "sam")': {
         Choices: [
           {
             Next: 'throw new Error("little")',
@@ -2506,23 +2555,23 @@ test("try { throw } catch { (maybe) throw } finally { task }", () => {
             Variable: "$.id",
           },
         ],
-        Default: "task(undefined)",
+        Default: "task()",
         Type: "Choice",
       },
       'throw new Error("little")': {
-        Next: "task(undefined)",
+        Next: "task()",
         Result: {
           message: "little",
         },
         ResultPath: "$.0_tmp",
         Type: "Pass",
       },
-      "task(undefined)": {
+      "task()": {
         Next: "exit finally",
         ResultSelector: "$.Payload",
         Parameters: {
           FunctionName: task.resource.functionName,
-          Payload: null,
+          Payload: undefined,
         },
         Resource: "arn:aws:states:::lambda:invoke",
         ResultPath: null,
@@ -2560,14 +2609,14 @@ test("try { throw } catch { (maybe) throw } finally { task }", () => {
 test("try { task() } catch { (maybe) throw } finally { task }", () => {
   const { stack, task } = initStepFunctionApp();
 
-  const definition = new ExpressStepFunction(
+  const definition = new ExpressStepFunction<{ id: string }, string | void>(
     stack,
     "fn",
-    (id: string): string | void => {
+    (input) => {
       try {
         task("1");
       } catch {
-        if (id === "sam") {
+        if (input.id === "sam") {
           throw new Error("little");
         }
       } finally {
@@ -2585,7 +2634,7 @@ test("try { task() } catch { (maybe) throw } finally { task }", () => {
         Catch: [
           {
             ErrorEquals: ["States.ALL"],
-            Next: 'if(id == "sam")',
+            Next: 'if(input.id == "sam")',
             ResultPath: null,
           },
         ],
@@ -2599,7 +2648,7 @@ test("try { task() } catch { (maybe) throw } finally { task }", () => {
         ResultPath: null,
         Type: "Task",
       },
-      'if(id == "sam")': {
+      'if(input.id == "sam")': {
         Choices: [
           {
             Next: 'throw new Error("little")',
@@ -2772,30 +2821,29 @@ test("try { task() } catch(err) { (maybe) throw } finally { task }", () => {
 test("try { for-of } catch { (maybe) throw } finally { task }", () => {
   const { stack, task } = initStepFunctionApp();
 
-  const definition = new ExpressStepFunction(
-    stack,
-    "fn",
-    (items: string[]): string | void => {
-      try {
-        for (const item of items) {
-          task(item);
-        }
-      } catch (err: any) {
-        if (err.message === "you dun' goofed") {
-          throw new Error("little");
-        }
-      } finally {
-        // task should run after both throws
-        // for second throw, an error should be re-thrown
-        task("2");
+  const definition = new ExpressStepFunction<
+    { items: string[] },
+    string | void
+  >(stack, "fn", (input): string | void => {
+    try {
+      for (const item of input.items) {
+        task(item);
       }
+    } catch (err: any) {
+      if (err.message === "you dun' goofed") {
+        throw new Error("little");
+      }
+    } finally {
+      // task should run after both throws
+      // for second throw, an error should be re-thrown
+      task("2");
     }
-  ).definition;
+  }).definition;
 
   expect(definition).toEqual({
-    StartAt: "for(item of items)",
+    StartAt: "for(item of input.items)",
     States: {
-      "for(item of items)": {
+      "for(item of input.items)": {
         Catch: [
           {
             ErrorEquals: ["States.ALL"],
@@ -2904,30 +2952,29 @@ test("try { for-of } catch { (maybe) throw } finally { task }", () => {
 test("for-of { try { task() } catch (err) { if(err) throw } finally { task() } }", () => {
   const { stack, task } = initStepFunctionApp();
 
-  const definition = new ExpressStepFunction(
-    stack,
-    "fn",
-    (items: string[]): string | void => {
-      for (const item of items) {
-        try {
-          task(item);
-        } catch (err: any) {
-          if (err.message === "you dun' goofed") {
-            throw new Error("little");
-          }
-        } finally {
-          // task should run after both throws
-          // for second throw, an error should be re-thrown
-          task("2");
+  const definition = new ExpressStepFunction<
+    { items: string[] },
+    string | void
+  >(stack, "fn", (input): string | void => {
+    for (const item of input.items) {
+      try {
+        task(item);
+      } catch (err: any) {
+        if (err.message === "you dun' goofed") {
+          throw new Error("little");
         }
+      } finally {
+        // task should run after both throws
+        // for second throw, an error should be re-thrown
+        task("2");
       }
     }
-  ).definition;
+  }).definition;
 
   expect(definition).toEqual({
-    StartAt: "for(item of items)",
+    StartAt: "for(item of input.items)",
     States: {
-      "for(item of items)": {
+      "for(item of input.items)": {
         ItemsPath: "$.items",
         Iterator: {
           StartAt: "task(item)",
@@ -3048,7 +3095,7 @@ test("while (cond) { cond = task() }", () => {
       "while (cond == undefined)": {
         Choices: [
           {
-            Next: "cond = task(undefined)",
+            Next: "cond = task()",
             Or: [
               {
                 IsPresent: false,
@@ -3064,12 +3111,12 @@ test("while (cond) { cond = task() }", () => {
         Default: "return null",
         Type: "Choice",
       },
-      "cond = task(undefined)": {
+      "cond = task()": {
         Next: "while (cond == undefined)",
         ResultSelector: "$.Payload",
         Parameters: {
           FunctionName: task.resource.functionName,
-          Payload: null,
+          Payload: undefined,
         },
         Resource: "arn:aws:states:::lambda:invoke",
         ResultPath: "$.cond",
@@ -3100,7 +3147,7 @@ test("while (cond); cond = task()", () => {
       "while (cond == undefined)": {
         Choices: [
           {
-            Next: "cond = task(undefined)",
+            Next: "cond = task()",
             Or: [
               {
                 IsPresent: false,
@@ -3116,12 +3163,12 @@ test("while (cond); cond = task()", () => {
         Default: "return null",
         Type: "Choice",
       },
-      "cond = task(undefined)": {
+      "cond = task()": {
         Next: "while (cond == undefined)",
         ResultSelector: "$.Payload",
         Parameters: {
           FunctionName: task.resource.functionName,
-          Payload: null,
+          Payload: undefined,
         },
         Resource: "arn:aws:states:::lambda:invoke",
         ResultPath: "$.cond",
@@ -3149,12 +3196,12 @@ test("let cond; do { cond = task() } while (cond)", () => {
   }).definition;
 
   expect(definition).toEqual({
-    StartAt: "cond = task(undefined)",
+    StartAt: "cond = task()",
     States: {
       "while (cond == undefined)": {
         Choices: [
           {
-            Next: "cond = task(undefined)",
+            Next: "cond = task()",
             Or: [
               {
                 IsPresent: false,
@@ -3170,12 +3217,12 @@ test("let cond; do { cond = task() } while (cond)", () => {
         Default: "return null",
         Type: "Choice",
       },
-      "cond = task(undefined)": {
+      "cond = task()": {
         Next: "while (cond == undefined)",
         ResultSelector: "$.Payload",
         Parameters: {
           FunctionName: task.resource.functionName,
-          Payload: null,
+          Payload: undefined,
         },
         Resource: "arn:aws:states:::lambda:invoke",
         ResultPath: "$.cond",
@@ -3195,14 +3242,17 @@ test("let cond; do { cond = task() } while (cond)", () => {
 
 test("list.map(item => task(item))", () => {
   const { stack, task } = initStepFunctionApp();
-  const definition = new ExpressStepFunction(stack, "fn", (list: string[]) => {
-    return list.map((item) => task(item));
+  const definition = new ExpressStepFunction<
+    { list: string[] },
+    (number | null)[]
+  >(stack, "fn", (input) => {
+    return input.list.map((item) => task(item));
   }).definition;
 
   expect(definition).toEqual({
-    StartAt: "return list.map(function(item))",
+    StartAt: "return input.list.map(function(item))",
     States: {
-      "return list.map(function(item))": {
+      "return input.list.map(function(item))": {
         End: true,
         ItemsPath: "$.list",
         Iterator: {
@@ -3234,8 +3284,11 @@ test("list.map(item => task(item))", () => {
 
 test("list.map((item, i) => if (i == 0) task(item))", () => {
   const { stack, task } = initStepFunctionApp();
-  const definition = new ExpressStepFunction(stack, "fn", (list: string[]) => {
-    return list.map((item, i) => {
+  const definition = new ExpressStepFunction<
+    { list: string[] },
+    (number | null)[]
+  >(stack, "fn", (input) => {
+    return input.list.map((item, i) => {
       if (i === 0) {
         return task(item);
       } else {
@@ -3245,9 +3298,9 @@ test("list.map((item, i) => if (i == 0) task(item))", () => {
   }).definition;
 
   expect(definition).toEqual({
-    StartAt: "return list.map(function(item, i))",
+    StartAt: "return input.list.map(function(item, i))",
     States: {
-      "return list.map(function(item, i))": {
+      "return input.list.map(function(item, i))": {
         Type: "Map",
         End: true,
         ItemsPath: "$.list",
@@ -3299,20 +3352,23 @@ test("list.map((item, i) => if (i == 0) task(item))", () => {
 
 test("list.map((item, i, list) => if (i == 0) task(item) else task(list[0]))", () => {
   const { stack, task } = initStepFunctionApp();
-  const definition = new ExpressStepFunction(stack, "fn", (list: string[]) => {
-    return list.map((item, i) => {
+  const definition = new ExpressStepFunction<
+    { list: string[] },
+    (number | null)[]
+  >(stack, "fn", (input) => {
+    return input.list.map((item, i) => {
       if (i === 0) {
         return task(item);
       } else {
-        return task(list[0]);
+        return task(input.list[0]);
       }
     });
   }).definition;
 
   expect(definition).toEqual({
-    StartAt: "return list.map(function(item, i))",
+    StartAt: "return input.list.map(function(item, i))",
     States: {
-      "return list.map(function(item, i))": {
+      "return input.list.map(function(item, i))": {
         End: true,
         ItemsPath: "$.list",
         Iterator: {
@@ -3326,7 +3382,7 @@ test("list.map((item, i, list) => if (i == 0) task(item) else task(list[0]))", (
                   Variable: "$.i",
                 },
               ],
-              Default: "return task(list[0])",
+              Default: "return task(input.list[0])",
               Type: "Choice",
             },
             "return task(item)": {
@@ -3340,7 +3396,7 @@ test("list.map((item, i, list) => if (i == 0) task(item) else task(list[0]))", (
               ResultPath: "$",
               Type: "Task",
             },
-            "return task(list[0])": {
+            "return task(input.list[0])": {
               End: true,
               ResultSelector: "$.Payload",
               Parameters: {
@@ -3367,18 +3423,21 @@ test("list.map((item, i, list) => if (i == 0) task(item) else task(list[0]))", (
 
 test("try { list.map(item => task(item)) }", () => {
   const { stack, task } = initStepFunctionApp();
-  const definition = new ExpressStepFunction(stack, "fn", (list: string[]) => {
+  const definition = new ExpressStepFunction<
+    { list: string[] },
+    (null | number)[] | null
+  >(stack, "fn", (input) => {
     try {
-      return list.map((item) => task(item));
+      return input.list.map((item) => task(item));
     } catch {
       return null;
     }
   }).definition;
 
   expect(definition).toEqual({
-    StartAt: "return list.map(function(item))",
+    StartAt: "return input.list.map(function(item))",
     States: {
-      "return list.map(function(item))": {
+      "return input.list.map(function(item))": {
         Catch: [
           {
             ErrorEquals: ["States.ALL"],
@@ -3425,8 +3484,11 @@ test("try { list.map(item => task(item)) }", () => {
 
 test("try { list.map(item => task(item)) }", () => {
   const { stack, task } = initStepFunctionApp();
-  const definition = new ExpressStepFunction(stack, "fn", (list: string[]) => {
-    return list.map((item) => {
+  const definition = new ExpressStepFunction<
+    { list: string[] },
+    (number | null)[]
+  >(stack, "fn", (input) => {
+    return input.list.map((item) => {
       try {
         return task(item);
       } catch {
@@ -3436,9 +3498,9 @@ test("try { list.map(item => task(item)) }", () => {
   }).definition;
 
   expect(definition).toEqual({
-    StartAt: "return list.map(function(item))",
+    StartAt: "return input.list.map(function(item))",
     States: {
-      "return list.map(function(item))": {
+      "return input.list.map(function(item))": {
         End: true,
         ItemsPath: "$.list",
         Iterator: {
@@ -3485,9 +3547,12 @@ test("try { list.map(item => task(item)) }", () => {
 
 test("try { list.map(item => throw) }", () => {
   const { stack } = initStepFunctionApp();
-  const definition = new ExpressStepFunction(stack, "fn", (list: string[]) => {
+  const definition = new ExpressStepFunction<
+    { list: string[] },
+    null | string[]
+  >(stack, "fn", (input) => {
     try {
-      return list.map(() => {
+      return input.list.map(() => {
         throw new Error("cause");
       });
     } catch {
@@ -3496,9 +3561,9 @@ test("try { list.map(item => throw) }", () => {
   }).definition;
 
   expect(definition).toEqual({
-    StartAt: "return list.map(function())",
+    StartAt: "return input.list.map(function())",
     States: {
-      "return list.map(function())": {
+      "return input.list.map(function())": {
         Catch: [
           {
             ErrorEquals: ["States.ALL"],
@@ -3537,9 +3602,12 @@ test("try { list.map(item => throw) }", () => {
 
 test("try { list.map(item => throw) } catch (err)", () => {
   const { stack } = initStepFunctionApp();
-  const definition = new ExpressStepFunction(stack, "fn", (list: string[]) => {
+  const definition = new ExpressStepFunction<
+    { list: string[] },
+    string[] | number
+  >(stack, "fn", (input) => {
     try {
-      return list.map(() => {
+      return input.list.map(() => {
         throw new Error("cause");
       });
     } catch (err: any) {
@@ -3552,9 +3620,9 @@ test("try { list.map(item => throw) } catch (err)", () => {
   }).definition;
 
   expect(definition).toEqual({
-    StartAt: "return list.map(function())",
+    StartAt: "return input.list.map(function())",
     States: {
-      "return list.map(function())": {
+      "return input.list.map(function())": {
         Catch: [
           {
             ErrorEquals: ["States.ALL"],
@@ -3622,14 +3690,18 @@ test("try { list.map(item => throw) } catch (err)", () => {
 
 test("list.forEach(item => task(item))", () => {
   const { stack, task } = initStepFunctionApp();
-  const definition = new ExpressStepFunction(stack, "fn", (list: string[]) => {
-    return list.forEach((item) => task(item));
-  }).definition;
+  const definition = new ExpressStepFunction<{ list: string[] }, void>(
+    stack,
+    "fn",
+    (input) => {
+      return input.list.forEach((item) => task(item));
+    }
+  ).definition;
 
   expect(definition).toEqual({
-    StartAt: "return list.forEach(function(item))",
+    StartAt: "return input.list.forEach(function(item))",
     States: {
-      "return list.forEach(function(item))": {
+      "return input.list.forEach(function(item))": {
         End: true,
         ItemsPath: "$.list",
         Iterator: {
@@ -3661,20 +3733,24 @@ test("list.forEach(item => task(item))", () => {
 
 test("list.forEach((item, i) => if (i == 0) task(item))", () => {
   const { stack, task } = initStepFunctionApp();
-  const definition = new ExpressStepFunction(stack, "fn", (list: string[]) => {
-    return list.forEach((item, i) => {
-      if (i === 0) {
-        return task(item);
-      } else {
-        return null;
-      }
-    });
-  }).definition;
+  const definition = new ExpressStepFunction<{ list: string[] }, void>(
+    stack,
+    "fn",
+    (input) => {
+      return input.list.forEach((item, i) => {
+        if (i === 0) {
+          return task(item);
+        } else {
+          return null;
+        }
+      });
+    }
+  ).definition;
 
   expect(definition).toEqual({
-    StartAt: "return list.forEach(function(item, i))",
+    StartAt: "return input.list.forEach(function(item, i))",
     States: {
-      "return list.forEach(function(item, i))": {
+      "return input.list.forEach(function(item, i))": {
         Type: "Map",
         End: true,
         ItemsPath: "$.list",
@@ -3726,20 +3802,24 @@ test("list.forEach((item, i) => if (i == 0) task(item))", () => {
 
 test("list.forEach((item, i, list) => if (i == 0) task(item) else task(list[0]))", () => {
   const { stack, task } = initStepFunctionApp();
-  const definition = new ExpressStepFunction(stack, "fn", (list: string[]) => {
-    return list.forEach((item, i) => {
-      if (i === 0) {
-        return task(item);
-      } else {
-        return task(list[0]);
-      }
-    });
-  }).definition;
+  const definition = new ExpressStepFunction<{ list: string[] }, void>(
+    stack,
+    "fn",
+    (input) => {
+      return input.list.forEach((item, i) => {
+        if (i === 0) {
+          return task(item);
+        } else {
+          return task(input.list[0]);
+        }
+      });
+    }
+  ).definition;
 
   expect(definition).toEqual({
-    StartAt: "return list.forEach(function(item, i))",
+    StartAt: "return input.list.forEach(function(item, i))",
     States: {
-      "return list.forEach(function(item, i))": {
+      "return input.list.forEach(function(item, i))": {
         End: true,
         ItemsPath: "$.list",
         Iterator: {
@@ -3753,7 +3833,7 @@ test("list.forEach((item, i, list) => if (i == 0) task(item) else task(list[0]))
                   Variable: "$.i",
                 },
               ],
-              Default: "return task(list[0])",
+              Default: "return task(input.list[0])",
               Type: "Choice",
             },
             "return task(item)": {
@@ -3767,7 +3847,7 @@ test("list.forEach((item, i, list) => if (i == 0) task(item) else task(list[0]))
               ResultPath: "$",
               Type: "Task",
             },
-            "return task(list[0])": {
+            "return task(input.list[0])": {
               End: true,
               ResultSelector: "$.Payload",
               Parameters: {
@@ -3794,18 +3874,22 @@ test("list.forEach((item, i, list) => if (i == 0) task(item) else task(list[0]))
 
 test("try { list.forEach(item => task(item)) }", () => {
   const { stack, task } = initStepFunctionApp();
-  const definition = new ExpressStepFunction(stack, "fn", (list: string[]) => {
-    try {
-      return list.forEach((item) => task(item));
-    } catch {
-      return null;
+  const definition = new ExpressStepFunction<{ list: string[] }, void | null>(
+    stack,
+    "fn",
+    (input) => {
+      try {
+        return input.list.forEach((item) => task(item));
+      } catch {
+        return null;
+      }
     }
-  }).definition;
+  ).definition;
 
   expect(definition).toEqual({
-    StartAt: "return list.forEach(function(item))",
+    StartAt: "return input.list.forEach(function(item))",
     States: {
-      "return list.forEach(function(item))": {
+      "return input.list.forEach(function(item))": {
         Catch: [
           {
             ErrorEquals: ["States.ALL"],
@@ -3852,20 +3936,24 @@ test("try { list.forEach(item => task(item)) }", () => {
 
 test("try { list.forEach(item => task(item)) }", () => {
   const { stack, task } = initStepFunctionApp();
-  const definition = new ExpressStepFunction(stack, "fn", (list: string[]) => {
-    return list.forEach((item) => {
-      try {
-        return task(item);
-      } catch {
-        return null;
-      }
-    });
-  }).definition;
+  const definition = new ExpressStepFunction<{ list: string[] }, void>(
+    stack,
+    "fn",
+    (input) => {
+      return input.list.forEach((item) => {
+        try {
+          return task(item);
+        } catch {
+          return null;
+        }
+      });
+    }
+  ).definition;
 
   expect(definition).toEqual({
-    StartAt: "return list.forEach(function(item))",
+    StartAt: "return input.list.forEach(function(item))",
     States: {
-      "return list.forEach(function(item))": {
+      "return input.list.forEach(function(item))": {
         End: true,
         ItemsPath: "$.list",
         Iterator: {
@@ -3912,20 +4000,24 @@ test("try { list.forEach(item => task(item)) }", () => {
 
 test("try { list.forEach(item => throw) }", () => {
   const { stack } = initStepFunctionApp();
-  const definition = new ExpressStepFunction(stack, "fn", (list: string[]) => {
-    try {
-      return list.forEach(() => {
-        throw new Error("cause");
-      });
-    } catch {
-      return null;
+  const definition = new ExpressStepFunction<{ list: string[] }, void | null>(
+    stack,
+    "fn",
+    (input) => {
+      try {
+        return input.list.forEach(() => {
+          throw new Error("cause");
+        });
+      } catch {
+        return null;
+      }
     }
-  }).definition;
+  ).definition;
 
   expect(definition).toEqual({
-    StartAt: "return list.forEach(function())",
+    StartAt: "return input.list.forEach(function())",
     States: {
-      "return list.forEach(function())": {
+      "return input.list.forEach(function())": {
         Catch: [
           {
             ErrorEquals: ["States.ALL"],
@@ -3964,24 +4056,28 @@ test("try { list.forEach(item => throw) }", () => {
 
 test("try { list.forEach(item => throw) } catch (err)", () => {
   const { stack } = initStepFunctionApp();
-  const definition = new ExpressStepFunction(stack, "fn", (list: string[]) => {
-    try {
-      return list.forEach(() => {
-        throw new Error("cause");
-      });
-    } catch (err: any) {
-      if (err.message === "cause") {
-        return 0;
-      } else {
-        return 1;
+  const definition = new ExpressStepFunction<{ list: string[] }, void | number>(
+    stack,
+    "fn",
+    (input) => {
+      try {
+        return input.list.forEach(() => {
+          throw new Error("cause");
+        });
+      } catch (err: any) {
+        if (err.message === "cause") {
+          return 0;
+        } else {
+          return 1;
+        }
       }
     }
-  }).definition;
+  ).definition;
 
   expect(definition).toEqual({
-    StartAt: "return list.forEach(function())",
+    StartAt: "return input.list.forEach(function())",
     States: {
-      "return list.forEach(function())": {
+      "return input.list.forEach(function())": {
         Catch: [
           {
             ErrorEquals: ["States.ALL"],
@@ -4049,14 +4145,17 @@ test("try { list.forEach(item => throw) } catch (err)", () => {
 
 test("return $SFN.map(list, (item) => task(item))", () => {
   const { stack, task } = initStepFunctionApp();
-  const definition = new ExpressStepFunction(stack, "fn", (list: string[]) => {
-    return $SFN.map(list, (item) => task(item));
+  const definition = new ExpressStepFunction<
+    { list: string[] },
+    (number | null)[]
+  >(stack, "fn", (input) => {
+    return $SFN.map(input.list, (item) => task(item));
   }).definition;
 
   expect(definition).toEqual({
-    StartAt: "return $SFN.map(list, function(item))",
+    StartAt: "return $SFN.map(input.list, function(item))",
     States: {
-      "return $SFN.map(list, function(item))": {
+      "return $SFN.map(input.list, function(item))": {
         End: true,
         ItemsPath: "$.list",
         Iterator: {
@@ -4087,14 +4186,17 @@ test("return $SFN.map(list, (item) => task(item))", () => {
 
 test("return $SFN.map(list, {maxConcurrency: 2} (item) => task(item))", () => {
   const { stack, task } = initStepFunctionApp();
-  const definition = new ExpressStepFunction(stack, "fn", (list: string[]) => {
-    return $SFN.map(list, { maxConcurrency: 2 }, (item) => task(item));
+  const definition = new ExpressStepFunction<
+    { list: string[] },
+    (number | null)[]
+  >(stack, "fn", (input) => {
+    return $SFN.map(input.list, { maxConcurrency: 2 }, (item) => task(item));
   }).definition;
 
   expect(definition).toEqual({
-    StartAt: "return $SFN.map(list, {maxConcurrency: 2}, function(item))",
+    StartAt: "return $SFN.map(input.list, {maxConcurrency: 2}, function(item))",
     States: {
-      "return $SFN.map(list, {maxConcurrency: 2}, function(item))": {
+      "return $SFN.map(input.list, {maxConcurrency: 2}, function(item))": {
         End: true,
         ItemsPath: "$.list",
         MaxConcurrency: 2,
@@ -4126,14 +4228,18 @@ test("return $SFN.map(list, {maxConcurrency: 2} (item) => task(item))", () => {
 
 test("$SFN.map(list, (item) => task(item))", () => {
   const { stack, task } = initStepFunctionApp();
-  const definition = new ExpressStepFunction(stack, "fn", (list: string[]) => {
-    $SFN.map(list, (item) => task(item));
-  }).definition;
+  const definition = new ExpressStepFunction<{ list: string[] }, void>(
+    stack,
+    "fn",
+    (input) => {
+      $SFN.map(input.list, (item) => task(item));
+    }
+  ).definition;
 
   expect(definition).toEqual({
-    StartAt: "$SFN.map(list, function(item))",
+    StartAt: "$SFN.map(input.list, function(item))",
     States: {
-      "$SFN.map(list, function(item))": {
+      "$SFN.map(input.list, function(item))": {
         ItemsPath: "$.list",
         Next: "return null",
         Iterator: {
@@ -4172,15 +4278,18 @@ test("$SFN.map(list, (item) => task(item))", () => {
 
 test("result = $SFN.map(list, (item) => task(item))", () => {
   const { stack, task } = initStepFunctionApp();
-  const definition = new ExpressStepFunction(stack, "fn", (list: string[]) => {
-    const result = $SFN.map(list, (item) => task(item));
+  const definition = new ExpressStepFunction<
+    { list: string[] },
+    (number | null)[]
+  >(stack, "fn", (input) => {
+    const result = $SFN.map(input.list, (item) => task(item));
     return result;
   }).definition;
 
   expect(definition).toEqual({
-    StartAt: "result = $SFN.map(list, function(item))",
+    StartAt: "result = $SFN.map(input.list, function(item))",
     States: {
-      "result = $SFN.map(list, function(item))": {
+      "result = $SFN.map(input.list, function(item))": {
         ItemsPath: "$.list",
         Iterator: {
           StartAt: "return task(item)",
@@ -4216,8 +4325,11 @@ test("result = $SFN.map(list, (item) => task(item))", () => {
 
 test("return $SFN.map(list, (item) => try { task(item)) } catch { return null }", () => {
   const { stack, task } = initStepFunctionApp();
-  const definition = new ExpressStepFunction(stack, "fn", (list: string[]) => {
-    return $SFN.map(list, (item) => {
+  const definition = new ExpressStepFunction<
+    { list: string[] },
+    (number | null)[]
+  >(stack, "fn", (input) => {
+    return $SFN.map(input.list, (item) => {
       try {
         return task(item);
       } catch {
@@ -4227,9 +4339,9 @@ test("return $SFN.map(list, (item) => try { task(item)) } catch { return null }"
   }).definition;
 
   expect(definition).toEqual({
-    StartAt: "return $SFN.map(list, function(item))",
+    StartAt: "return $SFN.map(input.list, function(item))",
     States: {
-      "return $SFN.map(list, function(item))": {
+      "return $SFN.map(input.list, function(item))": {
         End: true,
         ItemsPath: "$.list",
         Iterator: {
@@ -4275,18 +4387,21 @@ test("return $SFN.map(list, (item) => try { task(item)) } catch { return null }"
 
 test("try { $SFN.map(list, (item) => task(item)) } catch { return null }", () => {
   const { stack, task } = initStepFunctionApp();
-  const definition = new ExpressStepFunction(stack, "fn", (list: string[]) => {
+  const definition = new ExpressStepFunction<
+    { list: string[] },
+    (number | null)[] | null
+  >(stack, "fn", (input) => {
     try {
-      return $SFN.map(list, (item) => task(item));
+      return $SFN.map(input.list, (item) => task(item));
     } catch {
       return null;
     }
   }).definition;
 
   expect(definition).toEqual({
-    StartAt: "return $SFN.map(list, function(item))",
+    StartAt: "return $SFN.map(input.list, function(item))",
     States: {
-      "return $SFN.map(list, function(item))": {
+      "return $SFN.map(input.list, function(item))": {
         Catch: [
           {
             ErrorEquals: ["States.ALL"],
@@ -4332,14 +4447,18 @@ test("try { $SFN.map(list, (item) => task(item)) } catch { return null }", () =>
 
 test("return $SFN.forEach(list, (item) => task(item))", () => {
   const { stack, task } = initStepFunctionApp();
-  const definition = new ExpressStepFunction(stack, "fn", (list: string[]) => {
-    return $SFN.forEach(list, (item) => task(item));
-  }).definition;
+  const definition = new ExpressStepFunction<{ list: string[] }, void>(
+    stack,
+    "fn",
+    (input) => {
+      return $SFN.forEach(input.list, (item) => task(item));
+    }
+  ).definition;
 
   expect(definition).toEqual({
-    StartAt: "return $SFN.forEach(list, function(item))",
+    StartAt: "return $SFN.forEach(input.list, function(item))",
     States: {
-      "return $SFN.forEach(list, function(item))": {
+      "return $SFN.forEach(input.list, function(item))": {
         End: true,
         ItemsPath: "$.list",
         Iterator: {
@@ -4370,14 +4489,21 @@ test("return $SFN.forEach(list, (item) => task(item))", () => {
 
 test("return $SFN.forEach(list, {maxConcurrency: 2} (item) => task(item))", () => {
   const { stack, task } = initStepFunctionApp();
-  const definition = new ExpressStepFunction(stack, "fn", (list: string[]) => {
-    return $SFN.forEach(list, { maxConcurrency: 2 }, (item) => task(item));
-  }).definition;
+  const definition = new ExpressStepFunction<{ list: string[] }, void>(
+    stack,
+    "fn",
+    (input) => {
+      return $SFN.forEach(input.list, { maxConcurrency: 2 }, (item) =>
+        task(item)
+      );
+    }
+  ).definition;
 
   expect(definition).toEqual({
-    StartAt: "return $SFN.forEach(list, {maxConcurrency: 2}, function(item))",
+    StartAt:
+      "return $SFN.forEach(input.list, {maxConcurrency: 2}, function(item))",
     States: {
-      "return $SFN.forEach(list, {maxConcurrency: 2}, function(item))": {
+      "return $SFN.forEach(input.list, {maxConcurrency: 2}, function(item))": {
         End: true,
         ItemsPath: "$.list",
         MaxConcurrency: 2,
@@ -4409,14 +4535,18 @@ test("return $SFN.forEach(list, {maxConcurrency: 2} (item) => task(item))", () =
 
 test("$SFN.forEach(list, (item) => task(item))", () => {
   const { stack, task } = initStepFunctionApp();
-  const definition = new ExpressStepFunction(stack, "fn", (list: string[]) => {
-    $SFN.forEach(list, (item) => task(item));
-  }).definition;
+  const definition = new ExpressStepFunction<{ list: string[] }, void>(
+    stack,
+    "fn",
+    (input) => {
+      $SFN.forEach(input.list, (item) => task(item));
+    }
+  ).definition;
 
   expect(definition).toEqual({
-    StartAt: "$SFN.forEach(list, function(item))",
+    StartAt: "$SFN.forEach(input.list, function(item))",
     States: {
-      "$SFN.forEach(list, function(item))": {
+      "$SFN.forEach(input.list, function(item))": {
         ItemsPath: "$.list",
         Next: "return null",
         Iterator: {
@@ -4455,15 +4585,19 @@ test("$SFN.forEach(list, (item) => task(item))", () => {
 
 test("result = $SFN.forEach(list, (item) => task(item))", () => {
   const { stack, task } = initStepFunctionApp();
-  const definition = new ExpressStepFunction(stack, "fn", (list: string[]) => {
-    const result = $SFN.forEach(list, (item) => task(item));
-    return result;
-  }).definition;
+  const definition = new ExpressStepFunction<{ list: string[] }, void>(
+    stack,
+    "fn",
+    (input) => {
+      const result = $SFN.forEach(input.list, (item) => task(item));
+      return result;
+    }
+  ).definition;
 
   expect(definition).toEqual({
-    StartAt: "result = $SFN.forEach(list, function(item))",
+    StartAt: "result = $SFN.forEach(input.list, function(item))",
     States: {
-      "result = $SFN.forEach(list, function(item))": {
+      "result = $SFN.forEach(input.list, function(item))": {
         ItemsPath: "$.list",
         Iterator: {
           StartAt: "return task(item)",
@@ -4499,20 +4633,24 @@ test("result = $SFN.forEach(list, (item) => task(item))", () => {
 
 test("return $SFN.forEach(list, (item) => try { task(item)) } catch { return null }", () => {
   const { stack, task } = initStepFunctionApp();
-  const definition = new ExpressStepFunction(stack, "fn", (list: string[]) => {
-    return $SFN.forEach(list, (item) => {
-      try {
-        return task(item);
-      } catch {
-        return null;
-      }
-    });
-  }).definition;
+  const definition = new ExpressStepFunction<{ list: string[] }, void>(
+    stack,
+    "fn",
+    (input) => {
+      return $SFN.forEach(input.list, (item) => {
+        try {
+          return task(item);
+        } catch {
+          return null;
+        }
+      });
+    }
+  ).definition;
 
   expect(definition).toEqual({
-    StartAt: "return $SFN.forEach(list, function(item))",
+    StartAt: "return $SFN.forEach(input.list, function(item))",
     States: {
-      "return $SFN.forEach(list, function(item))": {
+      "return $SFN.forEach(input.list, function(item))": {
         End: true,
         ItemsPath: "$.list",
         Iterator: {
@@ -4558,18 +4696,22 @@ test("return $SFN.forEach(list, (item) => try { task(item)) } catch { return nul
 
 test("try { $SFN.forEach(list, (item) => task(item)) } catch { return null }", () => {
   const { stack, task } = initStepFunctionApp();
-  const definition = new ExpressStepFunction(stack, "fn", (list: string[]) => {
-    try {
-      return $SFN.forEach(list, (item) => task(item));
-    } catch {
-      return null;
+  const definition = new ExpressStepFunction<{ list: string[] }, void | null>(
+    stack,
+    "fn",
+    (input) => {
+      try {
+        return $SFN.forEach(input.list, (item) => task(item));
+      } catch {
+        return null;
+      }
     }
-  }).definition;
+  ).definition;
 
   expect(definition).toEqual({
-    StartAt: "return $SFN.forEach(list, function(item))",
+    StartAt: "return $SFN.forEach(input.list, function(item))",
     States: {
-      "return $SFN.forEach(list, function(item))": {
+      "return $SFN.forEach(input.list, function(item))": {
         Catch: [
           {
             ErrorEquals: ["States.ALL"],
@@ -4744,9 +4886,9 @@ test("return $SFN.parallel(() => try { task() } catch { return null })) }", () =
       "return $SFN.parallel([function()])": {
         Branches: [
           {
-            StartAt: "return task(undefined)",
+            StartAt: "return task()",
             States: {
-              "return task(undefined)": {
+              "return task()": {
                 Catch: [
                   {
                     ErrorEquals: ["States.ALL"],
@@ -4758,7 +4900,7 @@ test("return $SFN.parallel(() => try { task() } catch { return null })) }", () =
                 ResultSelector: "$.Payload",
                 Parameters: {
                   FunctionName: task.resource.functionName,
-                  Payload: null,
+                  Payload: undefined,
                 },
                 Resource: "arn:aws:states:::lambda:invoke",
                 ResultPath: "$",
@@ -4800,27 +4942,26 @@ test("return $SFN.parallel(() => try { task() } catch { return null })) }", () =
 
 test("return task({ key: items.filter(*) })", () => {
   const { stack, task } = initStepFunctionApp();
-  const definition = new ExpressStepFunction(
-    stack,
-    "fn",
-    (items: { str: string; items: string[] }[]) => {
-      return task({
-        equals: items.filter((item) => item.str === "hello"),
-        and: items.filter(
-          (item) => item.str === "hello" && item.items[0] === "hello"
-        ),
-        or: items.filter(
-          (item) => item.str === "hello" || item.items[0] === "hello"
-        ),
-      });
-    }
-  ).definition;
+  const definition = new ExpressStepFunction<
+    { items: { str: string; items: string[] }[] },
+    number | null
+  >(stack, "fn", (input) => {
+    return task({
+      equals: input.items.filter((item) => item.str === "hello"),
+      and: input.items.filter(
+        (item) => item.str === "hello" && item.items[0] === "hello"
+      ),
+      or: input.items.filter(
+        (item) => item.str === "hello" || item.items[0] === "hello"
+      ),
+    });
+  }).definition;
 
   expect(definition).toEqual({
     StartAt:
-      "return task({equals: items.filter(function(item)), and: items.filter(functi",
+      "return task({equals: input.items.filter(function(item)), and: input.items.f",
     States: {
-      "return task({equals: items.filter(function(item)), and: items.filter(functi":
+      "return task({equals: input.items.filter(function(item)), and: input.items.f":
         {
           Type: "Task",
           End: true,
@@ -4842,20 +4983,19 @@ test("return task({ key: items.filter(*) })", () => {
 
 test("template literal strings", () => {
   const { stack, task } = initStepFunctionApp();
-  const definition = new ExpressStepFunction(
-    stack,
-    "fn",
-    (obj: { str: string; items: string }) => {
-      return task({
-        key: `${obj.str} ${"hello"} ${obj.items[0]}`,
-      });
-    }
-  ).definition;
+  const definition = new ExpressStepFunction<
+    { obj: { str: string; items: string } },
+    number | null
+  >(stack, "fn", (input) => {
+    return task({
+      key: `${input.obj.str} ${"hello"} ${input.obj.items[0]}`,
+    });
+  }).definition;
 
   expect(definition).toEqual({
-    StartAt: "return task({key: `obj.str hello obj.items[0]`})",
+    StartAt: "return task({key: `input.obj.str hello input.obj.items[0]`})",
     States: {
-      "return task({key: `obj.str hello obj.items[0]`})": {
+      "return task({key: `input.obj.str hello input.obj.items[0]`})": {
         End: true,
         ResultSelector: "$.Payload",
         Parameters: {
@@ -4874,18 +5014,22 @@ test("template literal strings", () => {
 
 test("break from for-loop", () => {
   const { stack } = initStepFunctionApp();
-  const definition = new ExpressStepFunction(stack, "fn", (items: string[]) => {
-    for (const item of items) {
-      if (item === "hello") {
-        break;
+  const definition = new ExpressStepFunction<{ items: string[] }, void>(
+    stack,
+    "fn",
+    (input) => {
+      for (const item of input.items) {
+        if (item === "hello") {
+          break;
+        }
       }
     }
-  }).definition;
+  ).definition;
 
   expect(definition).toEqual({
-    StartAt: "for(item of items)",
+    StartAt: "for(item of input.items)",
     States: {
-      "for(item of items)": {
+      "for(item of input.items)": {
         Catch: [
           {
             ErrorEquals: ["Break"],
@@ -5016,18 +5160,22 @@ test("break from do-while-loop", () => {
 
 test("continue in for loop", () => {
   const { stack } = initStepFunctionApp();
-  const definition = new ExpressStepFunction(stack, "fn", (items: string[]) => {
-    for (const item of items) {
-      if (item === "hello") {
-        continue;
+  const definition = new ExpressStepFunction<{ items: string[] }, void>(
+    stack,
+    "fn",
+    (input) => {
+      for (const item of input.items) {
+        if (item === "hello") {
+          continue;
+        }
       }
     }
-  }).definition;
+  ).definition;
 
   expect(definition).toEqual({
-    StartAt: "for(item of items)",
+    StartAt: "for(item of input.items)",
     States: {
-      "for(item of items)": {
+      "for(item of input.items)": {
         ItemsPath: "$.items",
         Iterator: {
           StartAt: 'if(item == "hello")',
@@ -5076,14 +5224,18 @@ test("continue in for loop", () => {
 
 test("continue in while loop", () => {
   const { stack, task } = initStepFunctionApp();
-  const definition = new ExpressStepFunction(stack, "fn", (key: string) => {
-    while (true) {
-      if (key === "sam") {
-        continue;
+  const definition = new ExpressStepFunction<{ key: string }, void>(
+    stack,
+    "fn",
+    (input) => {
+      while (true) {
+        if (input.key === "sam") {
+          continue;
+        }
+        task(input.key);
       }
-      task(key);
     }
-  }).definition;
+  ).definition;
 
   expect(definition).toEqual({
     StartAt: "while (true)",
@@ -5092,14 +5244,14 @@ test("continue in while loop", () => {
         Choices: [
           {
             IsPresent: false,
-            Next: 'if(key == "sam")',
+            Next: 'if(input.key == "sam")',
             Variable: "$.0_true",
           },
         ],
         Default: "return null",
         Type: "Choice",
       },
-      'if(key == "sam")': {
+      'if(input.key == "sam")': {
         Choices: [
           {
             Next: "continue",
@@ -5107,7 +5259,7 @@ test("continue in while loop", () => {
             Variable: "$.key",
           },
         ],
-        Default: "task(key)",
+        Default: "task(input.key)",
         Type: "Choice",
       },
       continue: {
@@ -5115,7 +5267,7 @@ test("continue in while loop", () => {
         ResultPath: null,
         Type: "Pass",
       },
-      "task(key)": {
+      "task(input.key)": {
         Next: "while (true)",
         ResultSelector: "$.Payload",
         Parameters: {
@@ -5140,19 +5292,23 @@ test("continue in while loop", () => {
 
 test("continue in do..while loop", () => {
   const { stack, task } = initStepFunctionApp();
-  const definition = new ExpressStepFunction(stack, "fn", (key: string) => {
-    do {
-      if (key === "sam") {
-        continue;
-      }
-      task(key);
-    } while (true);
-  }).definition;
+  const definition = new ExpressStepFunction<{ key: string }, void>(
+    stack,
+    "fn",
+    (input) => {
+      do {
+        if (input.key === "sam") {
+          continue;
+        }
+        task(input.key);
+      } while (true);
+    }
+  ).definition;
 
   expect(definition).toEqual({
-    StartAt: 'if(key == "sam")',
+    StartAt: 'if(input.key == "sam")',
     States: {
-      'if(key == "sam")': {
+      'if(input.key == "sam")': {
         Choices: [
           {
             Next: "continue",
@@ -5160,15 +5316,15 @@ test("continue in do..while loop", () => {
             Variable: "$.key",
           },
         ],
-        Default: "task(key)",
+        Default: "task(input.key)",
         Type: "Choice",
       },
       continue: {
-        Next: 'if(key == "sam")',
+        Next: 'if(input.key == "sam")',
         ResultPath: null,
         Type: "Pass",
       },
-      "task(key)": {
+      "task(input.key)": {
         Next: "while (true)",
         ResultSelector: "$.Payload",
         Parameters: {
@@ -5183,7 +5339,7 @@ test("continue in do..while loop", () => {
         Choices: [
           {
             IsPresent: false,
-            Next: 'if(key == "sam")',
+            Next: 'if(input.key == "sam")',
             Variable: "$.0_true",
           },
         ],
@@ -5209,14 +5365,14 @@ test("return task(task())", () => {
   }).definition;
 
   expect(definition).toEqual({
-    StartAt: "0_tmp = task(undefined)",
+    StartAt: "0_tmp = task()",
     States: {
-      "0_tmp = task(undefined)": {
+      "0_tmp = task()": {
         Next: "return task(0_tmp)",
         ResultSelector: "$.Payload",
         Parameters: {
           FunctionName: task.resource.functionName,
-          Payload: null,
+          Payload: undefined,
         },
         Resource: "arn:aws:states:::lambda:invoke",
         ResultPath: "$.0_tmp",
@@ -5274,14 +5430,14 @@ test("while(true) { try { } catch { wait }", () => {
         Choices: [
           {
             IsPresent: false,
-            Next: "task(undefined)",
+            Next: "task()",
             Variable: "$.0_true",
           },
         ],
         Default: "return null",
         Type: "Choice",
       },
-      "task(undefined)": {
+      "task()": {
         Catch: [
           {
             ErrorEquals: ["States.ALL"],
@@ -5293,7 +5449,7 @@ test("while(true) { try { } catch { wait }", () => {
         ResultSelector: "$.Payload",
         Parameters: {
           FunctionName: task.resource.functionName,
-          Payload: null,
+          Payload: undefined,
         },
         Resource: "arn:aws:states:::lambda:invoke",
         ResultPath: null,

--- a/yarn.lock
+++ b/yarn.lock
@@ -989,6 +989,31 @@
   resolved "https://registry.yarnpkg.com/@gar/promisify/-/promisify-1.1.3.tgz#555193ab2e3bb3b6adc3d551c9c030d9e860daf6"
   integrity sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==
 
+"@graphql-tools/merge@8.2.6":
+  version "8.2.6"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/merge/-/merge-8.2.6.tgz#7fb615fa9c143c3151ff025e501d52bd48186d19"
+  integrity sha512-dkwTm4czMISi/Io47IVvq2Fl9q4TIGKpJ0VZjuXYdEFkECyH6A5uwxZfPVandZG+gQs8ocFFoa6RisiUJLZrJw==
+  dependencies:
+    "@graphql-tools/utils" "8.6.5"
+    tslib "~2.3.0"
+
+"@graphql-tools/schema@^8.3.1":
+  version "8.3.6"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/schema/-/schema-8.3.6.tgz#80cfe3eba53eb6390a60a30078d7efbdaa5cc0b7"
+  integrity sha512-7tWYRQ8hB/rv2zAtv2LtnQl4UybyJPtRz/VLKRmgi7+F5t8iYBahmmsxMDAYMWMmWMqEDiKk54TvAes+J069rQ==
+  dependencies:
+    "@graphql-tools/merge" "8.2.6"
+    "@graphql-tools/utils" "8.6.5"
+    tslib "~2.3.0"
+    value-or-promise "1.0.11"
+
+"@graphql-tools/utils@8.6.5", "@graphql-tools/utils@^8.5.1":
+  version "8.6.5"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/utils/-/utils-8.6.5.tgz#ac04571b03f854c7a938b2ab700516a6c6d32335"
+  integrity sha512-mjOtaWiS2WIqRz/cq5gaeM3sVrllcu2xbtHROw1su1v3xWa3D3dKgn8Lrl7+tvWs5WUVySsBss/VZ3WdoPkCrA==
+  dependencies:
+    tslib "~2.3.0"
+
 "@humanwhocodes/config-array@^0.9.2":
   version "0.9.5"
   resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.9.5.tgz#2cbaf9a89460da24b5ca6531b8bbfc23e1df50c7"
@@ -1617,6 +1642,14 @@ abbrev@1:
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
   integrity sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==
 
+accepts@~1.3.8:
+  version "1.3.8"
+  resolved "https://registry.yarnpkg.com/accepts/-/accepts-1.3.8.tgz#0bf0be125b67014adcb0b0921e62db7bffe16b2e"
+  integrity sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==
+  dependencies:
+    mime-types "~2.1.34"
+    negotiator "0.6.3"
+
 acorn-globals@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/acorn-globals/-/acorn-globals-6.0.0.tgz#46cdd39f0f8ff08a876619b55f5ac8a6dc770b45"
@@ -1688,6 +1721,49 @@ ajv@^6.10.0, ajv@^6.12.4:
     fast-json-stable-stringify "^2.0.0"
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
+
+amplify-appsync-simulator@^2.3.10:
+  version "2.3.10"
+  resolved "https://registry.yarnpkg.com/amplify-appsync-simulator/-/amplify-appsync-simulator-2.3.10.tgz#8fa08b540f4e7a805e373b99b16b00ede107a3bc"
+  integrity sha512-ANpn4s8YONICG0OAsZPMAKX/fxSAHS+AgUqWfTf5dqqCiI9TQYvg8JM0+ZNgySxbjlSCMuWFYD6PVez8BDs1+A==
+  dependencies:
+    "@graphql-tools/schema" "^8.3.1"
+    "@graphql-tools/utils" "^8.5.1"
+    amplify-velocity-template "1.4.7"
+    aws-sdk "^2.1084.0"
+    chalk "^4.1.1"
+    cors "^2.8.5"
+    dataloader "^2.0.0"
+    express "^4.17.3"
+    graphql "^14.5.8"
+    graphql-iso-date "^3.6.1"
+    graphql-subscriptions "^1.1.0"
+    ip "^1.1.5"
+    js-string-escape "^1.0.1"
+    jwt-decode "^2.2.0"
+    libphonenumber-js "1.9.47"
+    lodash "^4.17.21"
+    moment "^2.24.0"
+    moment-jdateformatparser "^1.2.1"
+    moment-timezone "0.5.27"
+    mqtt-connection "4.0.0"
+    nanoid "^3.3.1"
+    pino "^6.13.0"
+    portfinder "^1.0.25"
+    promise-toolbox "^0.20.0"
+    qlobber "3.1.0"
+    retimer "2.0.0"
+    slash "^3.0.0"
+    steed "^1.1.3"
+    uuid "^8.3.2"
+    ws "^7.5.7"
+
+amplify-velocity-template@1.4.7:
+  version "1.4.7"
+  resolved "https://registry.yarnpkg.com/amplify-velocity-template/-/amplify-velocity-template-1.4.7.tgz#1bd5375a8ef4d4aded3cb5b69bacee807377ab2b"
+  integrity sha512-WJifX5vBn5dwDF+fimd+m0yg20HsHCF+/gExbk/3UKVPzFr/eBNqDo2wO1T690RucnG+2HXnM9ZFuhxwDiPM6g==
+  dependencies:
+    lodash "^4.17.21"
 
 ansi-align@^3.0.0:
   version "3.0.1"
@@ -1765,6 +1841,11 @@ argparse@^2.0.1:
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-2.0.1.tgz#246f50f3ca78a3240f6c997e8a9bd1eac49e4b38"
   integrity sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
 
+array-flatten@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/array-flatten/-/array-flatten-1.1.1.tgz#9a5f699051b1e7073328f2a008968b64ea2955d2"
+  integrity sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=
+
 array-ify@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/array-ify/-/array-ify-1.0.0.tgz#9e528762b4a9066ad163a6962a364418e9626ece"
@@ -1800,6 +1881,13 @@ arrify@^1.0.1:
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
   integrity sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=
 
+async@^2.6.2:
+  version "2.6.3"
+  resolved "https://registry.yarnpkg.com/async/-/async-2.6.3.tgz#d72625e2344a3656e3a3ad4fa749fa83299d82ff"
+  integrity sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==
+  dependencies:
+    lodash "^4.17.14"
+
 asynckit@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
@@ -1809,6 +1897,11 @@ at-least-node@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/at-least-node/-/at-least-node-1.0.0.tgz#602cd4b46e844ad4effc92a8011a3c46e0238dc2"
   integrity sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==
+
+atomic-sleep@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/atomic-sleep/-/atomic-sleep-1.0.0.tgz#eb85b77a601fc932cfe432c5acd364a9e2c9075b"
+  integrity sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==
 
 aws-cdk-lib@2.17.0:
   version "2.17.0"
@@ -1829,6 +1922,21 @@ aws-sdk@^2.1079.0:
   version "2.1096.0"
   resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.1096.0.tgz#d41d6c6afe44b00977d4fe4c68e9450941d72931"
   integrity sha512-q+hotU57U8bGpz1pf5CkO4z630ay0xGJ9HedahKPZ0Xk3/X0GH+QFYPBWJ5IMTtO30bjfPH0zTaL2vJmMXLBrQ==
+  dependencies:
+    buffer "4.9.2"
+    events "1.1.1"
+    ieee754 "1.1.13"
+    jmespath "0.16.0"
+    querystring "0.2.0"
+    sax "1.2.1"
+    url "0.10.3"
+    uuid "3.3.2"
+    xml2js "0.4.19"
+
+aws-sdk@^2.1084.0:
+  version "2.1108.0"
+  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.1108.0.tgz#50ab79d144abbe9a98ecdf2a47253a713e44e7d0"
+  integrity sha512-BpoHW6vk8cXQDf0M+j7LSti7db4vIWocfUDTFbmkOT0hH9pR3f4IDzbnGzGmlka6IOFWkb9sVHl+P5S2meswOg==
   dependencies:
     buffer "4.9.2"
     events "1.1.1"
@@ -1906,10 +2014,35 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
-base64-js@^1.0.2:
+base64-js@^1.0.2, base64-js@^1.3.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
   integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
+
+bl@^4.0.2:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/bl/-/bl-4.1.0.tgz#451535264182bec2fbbc83a62ab98cf11d9f7b3a"
+  integrity sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==
+  dependencies:
+    buffer "^5.5.0"
+    inherits "^2.0.4"
+    readable-stream "^3.4.0"
+
+body-parser@1.19.2:
+  version "1.19.2"
+  resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.19.2.tgz#4714ccd9c157d44797b8b5607d72c0b89952f26e"
+  integrity sha512-SAAwOxgoCKMGs9uUAUFHygfLAyaniaoun6I8mFY9pRAJL9+Kec34aU+oIjDhTycub1jozEfEwx1W1IuOYxVSFw==
+  dependencies:
+    bytes "3.1.2"
+    content-type "~1.0.4"
+    debug "2.6.9"
+    depd "~1.1.2"
+    http-errors "1.8.1"
+    iconv-lite "0.4.24"
+    on-finished "~2.3.0"
+    qs "6.9.7"
+    raw-body "2.4.3"
+    type-is "~1.6.18"
 
 bowser@^2.11.0:
   version "2.11.0"
@@ -1996,10 +2129,23 @@ buffer@4.9.2:
     ieee754 "^1.1.4"
     isarray "^1.0.0"
 
+buffer@^5.5.0:
+  version "5.7.1"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.7.1.tgz#ba62e7c13133053582197160851a8f648e99eed0"
+  integrity sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==
+  dependencies:
+    base64-js "^1.3.1"
+    ieee754 "^1.1.13"
+
 builtins@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/builtins/-/builtins-1.0.3.tgz#cb94faeb61c8696451db36534e1422f94f0aee88"
   integrity sha1-y5T662HIaWRR2zZTThQi+U8K7og=
+
+bytes@3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.1.2.tgz#8b0beeb98605adf1b128fa4386403c009e0221a5"
+  integrity sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==
 
 cacache@^16.0.0:
   version "16.0.2"
@@ -2089,7 +2235,7 @@ chalk@^2.0.0, chalk@^2.4.2:
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
-chalk@^4.0.0, chalk@^4.1.0, chalk@^4.1.2:
+chalk@^4.0.0, chalk@^4.1.0, chalk@^4.1.1, chalk@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
   integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
@@ -2260,6 +2406,18 @@ constructs@10.0.0:
   version "10.0.0"
   resolved "https://registry.yarnpkg.com/constructs/-/constructs-10.0.0.tgz#a6d498540111f6d75663711d0fa65f32fc8f1786"
   integrity sha512-MIwjmrXZpM9RtwyrSD4HotDIQl8HTdIefQhU+MU1asvtSyVN3kK8kjeUOWMFb+fdyT4RX3QvvcaaPBluLEX1SA==
+
+content-disposition@0.5.4:
+  version "0.5.4"
+  resolved "https://registry.yarnpkg.com/content-disposition/-/content-disposition-0.5.4.tgz#8b82b4efac82512a02bb0b1dcec9d2c5e8eb5bfe"
+  integrity sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==
+  dependencies:
+    safe-buffer "5.2.1"
+
+content-type@~1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.4.tgz#e138cc75e040c727b1966fe5e5f8c9aee256fe3b"
+  integrity sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==
 
 conventional-changelog-angular@^5.0.12:
   version "5.0.13"
@@ -2440,10 +2598,28 @@ convert-source-map@^1.4.0, convert-source-map@^1.6.0, convert-source-map@^1.7.0:
   dependencies:
     safe-buffer "~5.1.1"
 
+cookie-signature@1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/cookie-signature/-/cookie-signature-1.0.6.tgz#e303a882b342cc3ee8ca513a79999734dab3ae2c"
+  integrity sha1-4wOogrNCzD7oylE6eZmXNNqzriw=
+
+cookie@0.4.2:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.2.tgz#0e41f24de5ecf317947c82fc789e06a884824432"
+  integrity sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==
+
 core-util-is@~1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.3.tgz#a6042d3634c2b27e9328f837b965fac83808db85"
   integrity sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==
+
+cors@^2.8.5:
+  version "2.8.5"
+  resolved "https://registry.yarnpkg.com/cors/-/cors-2.8.5.tgz#eac11da51592dd86b9f06f6e7ac293b3df875d29"
+  integrity sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==
+  dependencies:
+    object-assign "^4"
+    vary "^1"
 
 create-require@^1.1.0:
   version "1.1.1"
@@ -2495,10 +2671,22 @@ data-urls@^2.0.0:
     whatwg-mimetype "^2.3.0"
     whatwg-url "^8.0.0"
 
+dataloader@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/dataloader/-/dataloader-2.0.0.tgz#41eaf123db115987e21ca93c005cd7753c55fe6f"
+  integrity sha512-YzhyDAwA4TaQIhM5go+vCLmU0UikghC/t9DTQYZR2M/UvZ1MdOhPezSDZcjj9uqQJOMqjLcpWtyW2iNINdlatQ==
+
 dateformat@^3.0.0:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-3.0.3.tgz#a6e37499a4d9a9cf85ef5872044d62901c9889ae"
   integrity sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==
+
+debug@2.6.9, debug@^2.6.9:
+  version "2.6.9"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
+  integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
+  dependencies:
+    ms "2.0.0"
 
 debug@4, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2:
   version "4.3.4"
@@ -2507,14 +2695,7 @@ debug@4, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2:
   dependencies:
     ms "2.1.2"
 
-debug@^2.6.9:
-  version "2.6.9"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
-  integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
-  dependencies:
-    ms "2.0.0"
-
-debug@^3.2.7:
+debug@^3.1.1, debug@^3.2.7:
   version "3.2.7"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.7.tgz#72580b7e9145fb39b6676f9c5e5fb100b934179a"
   integrity sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==
@@ -2588,10 +2769,15 @@ delegates@^1.0.0:
   resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
   integrity sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=
 
-depd@^1.1.2:
+depd@^1.1.2, depd@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.2.tgz#9bcd52e14c097763e749b274c4346ed2e560b5a9"
   integrity sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=
+
+destroy@~1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/destroy/-/destroy-1.0.4.tgz#978857442c44749e4206613e37946205826abd80"
+  integrity sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=
 
 detect-indent@^6.0.0:
   version "6.1.0"
@@ -2661,6 +2847,21 @@ duplexer3@^0.1.4:
   resolved "https://registry.yarnpkg.com/duplexer3/-/duplexer3-0.1.4.tgz#ee01dd1cac0ed3cbc7fdbea37dc0a8f1ce002ce2"
   integrity sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=
 
+duplexify@^3.5.1:
+  version "3.7.1"
+  resolved "https://registry.yarnpkg.com/duplexify/-/duplexify-3.7.1.tgz#2a4df5317f6ccfd91f86d6fd25d8d8a103b88309"
+  integrity sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==
+  dependencies:
+    end-of-stream "^1.0.0"
+    inherits "^2.0.1"
+    readable-stream "^2.0.0"
+    stream-shift "^1.0.0"
+
+ee-first@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
+  integrity sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=
+
 electron-to-chromium@^1.4.84:
   version "1.4.88"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.88.tgz#ebe6a2573b563680c7a7bf3a51b9e465c9c501db"
@@ -2676,6 +2877,11 @@ emoji-regex@^8.0.0:
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
   integrity sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==
 
+encodeurl@~1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-1.0.2.tgz#ad3ff4c86ec2d029322f5a02c3a9a606c95b3f59"
+  integrity sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=
+
 encoding@^0.1.13:
   version "0.1.13"
   resolved "https://registry.yarnpkg.com/encoding/-/encoding-0.1.13.tgz#56574afdd791f54a8e9b2785c0582a2d26210fa9"
@@ -2683,7 +2889,7 @@ encoding@^0.1.13:
   dependencies:
     iconv-lite "^0.6.2"
 
-end-of-stream@^1.1.0:
+end-of-stream@^1.0.0, end-of-stream@^1.1.0:
   version "1.4.4"
   resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.4.tgz#5ae64a5f45057baf3626ec14da0ca5e4b2431eb0"
   integrity sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==
@@ -2756,6 +2962,11 @@ escape-goat@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/escape-goat/-/escape-goat-2.1.1.tgz#1b2dc77003676c457ec760b2dc68edb648188675"
   integrity sha512-8/uIhbG12Csjy2JEW7D9pHbreaVaS/OpN3ycnyvElTdwM5n6GY6W6e2IPemfvGZeUMqZ9A/3GqIZMgKnBhAw/Q==
+
+escape-html@~1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
+  integrity sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=
 
 escape-string-regexp@^1.0.5:
   version "1.0.5"
@@ -2947,6 +3158,11 @@ esutils@^2.0.2:
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
   integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
 
+etag@~1.8.1:
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/etag/-/etag-1.8.1.tgz#41ae2eeb65efa62268aebfea83ac7d79299b0887"
+  integrity sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=
+
 events@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/events/-/events-1.1.1.tgz#9ebdb7635ad099c70dcc4c2a1f5004288e8bd924"
@@ -2982,6 +3198,42 @@ expect@^27.5.1:
     jest-matcher-utils "^27.5.1"
     jest-message-util "^27.5.1"
 
+express@^4.17.3:
+  version "4.17.3"
+  resolved "https://registry.yarnpkg.com/express/-/express-4.17.3.tgz#f6c7302194a4fb54271b73a1fe7a06478c8f85a1"
+  integrity sha512-yuSQpz5I+Ch7gFrPCk4/c+dIBKlQUxtgwqzph132bsT6qhuzss6I8cLJQz7B3rFblzd6wtcI0ZbGltH/C4LjUg==
+  dependencies:
+    accepts "~1.3.8"
+    array-flatten "1.1.1"
+    body-parser "1.19.2"
+    content-disposition "0.5.4"
+    content-type "~1.0.4"
+    cookie "0.4.2"
+    cookie-signature "1.0.6"
+    debug "2.6.9"
+    depd "~1.1.2"
+    encodeurl "~1.0.2"
+    escape-html "~1.0.3"
+    etag "~1.8.1"
+    finalhandler "~1.1.2"
+    fresh "0.5.2"
+    merge-descriptors "1.0.1"
+    methods "~1.1.2"
+    on-finished "~2.3.0"
+    parseurl "~1.3.3"
+    path-to-regexp "0.1.7"
+    proxy-addr "~2.0.7"
+    qs "6.9.7"
+    range-parser "~1.2.1"
+    safe-buffer "5.2.1"
+    send "0.17.2"
+    serve-static "1.14.2"
+    setprototypeof "1.2.0"
+    statuses "~1.5.0"
+    type-is "~1.6.18"
+    utils-merge "1.0.1"
+    vary "~1.1.2"
+
 fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
@@ -3013,17 +3265,50 @@ fast-memoize@^2.5.2:
   resolved "https://registry.yarnpkg.com/fast-memoize/-/fast-memoize-2.5.2.tgz#79e3bb6a4ec867ea40ba0e7146816f6cdce9b57e"
   integrity sha512-Ue0LwpDYErFbmNnZSF0UH6eImUwDmogUO1jyE+JbN2gsQz/jICm1Ve7t9QT0rNSsfJt+Hs4/S3GnsDVjL4HVrw==
 
+fast-redact@^3.0.0:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/fast-redact/-/fast-redact-3.1.1.tgz#790fcff8f808c2e12fabbfb2be5cb2deda448fa0"
+  integrity sha512-odVmjC8x8jNeMZ3C+rPMESzXVSEU8tSWSHv9HFxP2mm89G/1WwqhrerJDQm9Zus8X6aoRgQDThKqptdNA6bt+A==
+
+fast-safe-stringify@^2.0.8:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz#c406a83b6e70d9e35ce3b30a81141df30aeba884"
+  integrity sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==
+
 fast-xml-parser@3.19.0:
   version "3.19.0"
   resolved "https://registry.yarnpkg.com/fast-xml-parser/-/fast-xml-parser-3.19.0.tgz#cb637ec3f3999f51406dd8ff0e6fc4d83e520d01"
   integrity sha512-4pXwmBplsCPv8FOY1WRakF970TjNGnGnfbOnLqjlYvMiF1SR3yOHyxMR/YCXpPTOspNF5gwudqktIP4VsWkvBg==
 
-fastq@^1.6.0:
+fastfall@^1.5.0:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/fastfall/-/fastfall-1.5.1.tgz#3fee03331a49d1d39b3cdf7a5e9cd66f475e7b94"
+  integrity sha1-P+4DMxpJ0dObPN96XpzWb0dee5Q=
+  dependencies:
+    reusify "^1.0.0"
+
+fastparallel@^2.2.0:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/fastparallel/-/fastparallel-2.4.1.tgz#0d984a5813ffa67f30b4a5cb4cb8cbe61c7ee5a5"
+  integrity sha512-qUmhxPgNHmvRjZKBFUNI0oZuuH9OlSIOXmJ98lhKPxMZZ7zS/Fi0wRHOihDSz0R1YiIOjxzOY4bq65YTcdBi2Q==
+  dependencies:
+    reusify "^1.0.4"
+    xtend "^4.0.2"
+
+fastq@^1.3.0, fastq@^1.6.0:
   version "1.13.0"
   resolved "https://registry.yarnpkg.com/fastq/-/fastq-1.13.0.tgz#616760f88a7526bdfc596b7cab8c18938c36b98c"
   integrity sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==
   dependencies:
     reusify "^1.0.4"
+
+fastseries@^1.7.0:
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/fastseries/-/fastseries-1.7.2.tgz#d22ce13b9433dff3388d91dbd6b8bda9b21a0f4b"
+  integrity sha1-0izhO5Qz3/M4jZHb1ri9qbIaD0s=
+  dependencies:
+    reusify "^1.0.0"
+    xtend "^4.0.0"
 
 fb-watchman@^2.0.0:
   version "2.0.1"
@@ -3057,6 +3342,19 @@ fill-range@^7.0.1:
   integrity sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==
   dependencies:
     to-regex-range "^5.0.1"
+
+finalhandler@~1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/finalhandler/-/finalhandler-1.1.2.tgz#b7e7d000ffd11938d0fdb053506f6ebabe9f587d"
+  integrity sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==
+  dependencies:
+    debug "2.6.9"
+    encodeurl "~1.0.2"
+    escape-html "~1.0.3"
+    on-finished "~2.3.0"
+    parseurl "~1.3.3"
+    statuses "~1.5.0"
+    unpipe "~1.0.0"
 
 find-up@5.0.0, find-up@^5.0.0:
   version "5.0.0"
@@ -3096,6 +3394,11 @@ flat-cache@^3.0.4:
     flatted "^3.1.0"
     rimraf "^3.0.2"
 
+flatstr@^1.0.12:
+  version "1.0.12"
+  resolved "https://registry.yarnpkg.com/flatstr/-/flatstr-1.0.12.tgz#c2ba6a08173edbb6c9640e3055b95e287ceb5931"
+  integrity sha512-4zPxDyhCyiN2wIAtSLI6gc82/EjqZc1onI4Mz/l0pWrAlsSfYH/2ZIcU+e3oA2wDwbzIWNKwa23F8rh6+DRWkw==
+
 flatted@^3.1.0:
   version "3.2.5"
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.5.tgz#76c8584f4fc843db64702a6bd04ab7a8bd666da3"
@@ -3110,10 +3413,20 @@ form-data@^3.0.0:
     combined-stream "^1.0.8"
     mime-types "^2.1.12"
 
+forwarded@0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/forwarded/-/forwarded-0.2.0.tgz#2269936428aad4c15c7ebe9779a84bf0b2a81811"
+  integrity sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==
+
 fp-and-or@^0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/fp-and-or/-/fp-and-or-0.1.3.tgz#e6fba83872a5853a56b3ebdf8d3167f5dfca1882"
   integrity sha512-wJaE62fLaB3jCYvY2ZHjZvmKK2iiLiiehX38rz5QZxtdN8fVPJDeZUiVvJrHStdTc+23LHlyZuSEKgFc0pxi2g==
+
+fresh@0.5.2:
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/fresh/-/fresh-0.5.2.tgz#3d8cadd90d976569fa835ab1f8e4b23a105605a7"
+  integrity sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=
 
 fs-access@^1.0.1:
   version "1.0.1"
@@ -3370,6 +3683,25 @@ graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.6, 
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.9.tgz#041b05df45755e587a24942279b9d113146e1c96"
   integrity sha512-NtNxqUcXgpW2iMrfqSfR73Glt39K+BLwWsPs94yR63v45T0Wbej7eRmL5cWfwEgqXnmjQp3zaJTshdRW/qC2ZQ==
 
+graphql-iso-date@^3.6.1:
+  version "3.6.1"
+  resolved "https://registry.yarnpkg.com/graphql-iso-date/-/graphql-iso-date-3.6.1.tgz#bd2d0dc886e0f954cbbbc496bbf1d480b57ffa96"
+  integrity sha512-AwFGIuYMJQXOEAgRlJlFL4H1ncFM8n8XmoVDTNypNOZyQ8LFDG2ppMFlsS862BSTCDcSUfHp8PD3/uJhv7t59Q==
+
+graphql-subscriptions@^1.1.0:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/graphql-subscriptions/-/graphql-subscriptions-1.2.1.tgz#2142b2d729661ddf967b7388f7cf1dd4cf2e061d"
+  integrity sha512-95yD/tKi24q8xYa7Q9rhQN16AYj5wPbrb8tmHGM3WRc9EBmWrG/0kkMl+tQG8wcEuE9ibR4zyOM31p5Sdr2v4g==
+  dependencies:
+    iterall "^1.3.0"
+
+graphql@^14.5.8:
+  version "14.7.0"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-14.7.0.tgz#7fa79a80a69be4a31c27dda824dc04dac2035a72"
+  integrity sha512-l0xWZpoPKpppFzMfvVyFmp9vLN7w/ZZJPefUicMCepfJeQ8sMcztloGYY9DfjVPo6tIUDzU5Hw3MUbIjj9AVVA==
+  dependencies:
+    iterall "^1.2.2"
+
 handlebars@^4.7.7:
   version "4.7.7"
   resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.7.7.tgz#9ce33416aad02dbd6c8fafa8240d5d98004945a1"
@@ -3467,6 +3799,17 @@ http-cache-semantics@^4.0.0, http-cache-semantics@^4.1.0:
   resolved "https://registry.yarnpkg.com/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz#49e91c5cbf36c9b94bcfcd71c23d5249ec74e390"
   integrity sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==
 
+http-errors@1.8.1:
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-1.8.1.tgz#7c3f28577cbc8a207388455dbd62295ed07bd68c"
+  integrity sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==
+  dependencies:
+    depd "~1.1.2"
+    inherits "2.0.4"
+    setprototypeof "1.2.0"
+    statuses ">= 1.5.0 < 2"
+    toidentifier "1.0.1"
+
 http-proxy-agent@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz#8a8c8ef7f5932ccf953c296ca8291b95aa74aa3a"
@@ -3524,7 +3867,7 @@ ieee754@1.1.13:
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.13.tgz#ec168558e95aa181fd87d37f55c32bbcb6708b84"
   integrity sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==
 
-ieee754@^1.1.4:
+ieee754@^1.1.13, ieee754@^1.1.4:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
   integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
@@ -3585,7 +3928,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@^2.0.3, inherits@~2.0.3:
+inherits@2, inherits@2.0.4, inherits@^2.0.1, inherits@^2.0.3, inherits@^2.0.4, inherits@~2.0.3:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -3618,6 +3961,11 @@ ip@^1.1.5:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/ip/-/ip-1.1.5.tgz#bdded70114290828c0a039e72ef25f5aaec4354a"
   integrity sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=
+
+ipaddr.js@1.9.1:
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-1.9.1.tgz#bff38543eeb8984825079ff3a2a8e6cbd46781b3"
+  integrity sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==
 
 is-arrayish@^0.2.1:
   version "0.2.1"
@@ -3849,6 +4197,11 @@ istanbul-reports@^3.1.3:
   dependencies:
     html-escaper "^2.0.0"
     istanbul-lib-report "^3.0.0"
+
+iterall@^1.2.2, iterall@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/iterall/-/iterall-1.3.0.tgz#afcb08492e2915cbd8a0884eb93a8c94d0d72fea"
+  integrity sha512-QZ9qOMdF+QLHxy1QIpUHUU1D5pS2CG2P69LF6L6CPjPYA/XMOmKV3PZpawHoAjHNyB0swdVTRxdYT4tbBbxqwg==
 
 jest-changed-files@^27.5.1:
   version "27.5.1"
@@ -4275,6 +4628,11 @@ jmespath@0.16.0:
   resolved "https://registry.yarnpkg.com/jmespath/-/jmespath-0.16.0.tgz#b15b0a85dfd4d930d43e69ed605943c802785076"
   integrity sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw==
 
+js-string-escape@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/js-string-escape/-/js-string-escape-1.0.1.tgz#e2625badbc0d67c7533e9edc1068c587ae4137ef"
+  integrity sha1-4mJbrbwNZ8dTPp7cEGjFh65BN+8=
+
 js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
@@ -4421,6 +4779,11 @@ jsonschema@^1.4.0:
   resolved "https://registry.yarnpkg.com/jsonschema/-/jsonschema-1.4.0.tgz#1afa34c4bc22190d8e42271ec17ac8b3404f87b2"
   integrity sha512-/YgW6pRMr6M7C+4o8kS+B/2myEpHCrxO4PEWnqJNBFMjn7EWXqlQ4tGwL6xTHeRplwuZmcAncdvfOad1nT2yMw==
 
+jwt-decode@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/jwt-decode/-/jwt-decode-2.2.0.tgz#7d86bd56679f58ce6a84704a657dd392bba81a79"
+  integrity sha1-fYa9VmefWM5qhHBKZX3TkruoGnk=
+
 keyv@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/keyv/-/keyv-3.1.0.tgz#ecc228486f69991e49e9476485a5be1e8fc5c4d9"
@@ -4474,6 +4837,11 @@ libnpmconfig@^1.2.1:
     figgy-pudding "^3.5.1"
     find-up "^3.0.0"
     ini "^1.3.5"
+
+libphonenumber-js@1.9.47:
+  version "1.9.47"
+  resolved "https://registry.yarnpkg.com/libphonenumber-js/-/libphonenumber-js-1.9.47.tgz#0cb3d6a3dd8d917d364da48a5355bc3b1d145f5b"
+  integrity sha512-FIWFLJ2jUJi8SCztgd2k/isQHZedh7xuxOVifqFLwG/ogZtdH9TXFK92w/KWFj1lwoadqVedtLO3Jqp0q67PZw==
 
 lines-and-columns@^1.1.6:
   version "1.2.4"
@@ -4535,7 +4903,7 @@ lodash.merge@^4.6.2:
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
 
-lodash@^4.17.15, lodash@^4.17.21, lodash@^4.7.0:
+lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.21, lodash@^4.7.0:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -4569,7 +4937,7 @@ make-dir@^3.0.0:
   dependencies:
     semver "^6.0.0"
 
-make-error@1.x, make-error@^1.1.1:
+make-error@1.x, make-error@^1.1.1, make-error@^1.3.2:
   version "1.3.6"
   resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.6.tgz#2eb2e37ea9b67c4891f684a1394799af484cf7a2"
   integrity sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==
@@ -4613,6 +4981,11 @@ map-obj@^4.0.0:
   resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-4.3.0.tgz#9304f906e93faae70880da102a9f1df0ea8bb05a"
   integrity sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==
 
+media-typer@0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"
+  integrity sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=
+
 meow@^8.0.0:
   version "8.1.2"
   resolved "https://registry.yarnpkg.com/meow/-/meow-8.1.2.tgz#bcbe45bda0ee1729d350c03cffc8395a36c4e897"
@@ -4630,6 +5003,11 @@ meow@^8.0.0:
     type-fest "^0.18.0"
     yargs-parser "^20.2.3"
 
+merge-descriptors@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/merge-descriptors/-/merge-descriptors-1.0.1.tgz#b00aaa556dd8b44568150ec9d1b953f3f90cbb61"
+  integrity sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=
+
 merge-stream@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/merge-stream/-/merge-stream-2.0.0.tgz#52823629a14dd00c9770fb6ad47dc6310f2c1f60"
@@ -4639,6 +5017,11 @@ merge2@^1.3.0, merge2@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
   integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
+
+methods@~1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
+  integrity sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=
 
 micromatch@^4.0.4:
   version "4.0.4"
@@ -4653,12 +5036,17 @@ mime-db@1.52.0:
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
   integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
 
-mime-types@^2.1.12:
+mime-types@^2.1.12, mime-types@~2.1.24, mime-types@~2.1.34:
   version "2.1.35"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
   integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
   dependencies:
     mime-db "1.52.0"
+
+mime@1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/mime/-/mime-1.6.0.tgz#32cd9e5c64553bd58d19a568af452acff04981b1"
+  integrity sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==
 
 mimic-fn@^2.1.0:
   version "2.1.0"
@@ -4702,6 +5090,11 @@ minimist@^1.2.0, minimist@^1.2.3, minimist@^1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
   integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
+
+minimist@^1.2.6:
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.6.tgz#8637a5b759ea0d6e98702cfb3a9283323c93af44"
+  integrity sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==
 
 minipass-collect@^1.0.2:
   version "1.0.2"
@@ -4765,6 +5158,13 @@ minizlib@^2.1.1, minizlib@^2.1.2:
     minipass "^3.0.0"
     yallist "^4.0.0"
 
+mkdirp@^0.5.5:
+  version "0.5.6"
+  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.6.tgz#7def03d2432dcae4ba1d611445c48396062255f6"
+  integrity sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==
+  dependencies:
+    minimist "^1.2.6"
+
 mkdirp@^1.0.3, mkdirp@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
@@ -4782,6 +5182,43 @@ modify-values@^1.0.0:
   resolved "https://registry.yarnpkg.com/modify-values/-/modify-values-1.0.1.tgz#b3939fa605546474e3e3e3c63d64bd43b4ee6022"
   integrity sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==
 
+moment-jdateformatparser@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/moment-jdateformatparser/-/moment-jdateformatparser-1.2.1.tgz#336c41ef7a6db8021d7ca086385a35fb8a648456"
+  integrity sha512-lpUeQtMaxmpK+pPPHGWMnqzgsB/nunbAGPg72mzvRNbxxeQ2uBurdq9EJmvJtOiYB6k/4T9kuvQFbb+8Tirn4A==
+
+moment-timezone@0.5.27:
+  version "0.5.27"
+  resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.27.tgz#73adec8139b6fe30452e78f210f27b1f346b8877"
+  integrity sha512-EIKQs7h5sAsjhPCqN6ggx6cEbs94GK050254TIJySD1bzoM5JTYDwAU1IoVOeTOL6Gm27kYJ51/uuvq1kIlrbw==
+  dependencies:
+    moment ">= 2.9.0"
+
+"moment@>= 2.9.0", moment@^2.24.0:
+  version "2.29.2"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.2.tgz#00910c60b20843bcba52d37d58c628b47b1f20e4"
+  integrity sha512-UgzG4rvxYpN15jgCmVJwac49h9ly9NurikMWGPdVxm8GZD6XjkKPxDTjQQ43gtGgnV3X0cAyWDdP2Wexoquifg==
+
+mqtt-connection@4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/mqtt-connection/-/mqtt-connection-4.0.0.tgz#f171f08edb113c880c67d5cca29b081338139f1e"
+  integrity sha512-hkgQ2DjScc7ShVga4IEyxKum+rUXCGxoSiiG1DacrGZ9lz0TNzGEybaIScexCNBnt8fepBbfnXa6t0yr/69vjw==
+  dependencies:
+    duplexify "^3.5.1"
+    inherits "^2.0.3"
+    mqtt-packet "^6.0.0"
+    safe-buffer "^5.1.1"
+    through2 "^2.0.1"
+
+mqtt-packet@^6.0.0:
+  version "6.10.0"
+  resolved "https://registry.yarnpkg.com/mqtt-packet/-/mqtt-packet-6.10.0.tgz#c8b507832c4152e3e511c0efa104ae4a64cd418f"
+  integrity sha512-ja8+mFKIHdB1Tpl6vac+sktqy3gA8t9Mduom1BA75cI+R9AHnZOiaBQwpGiWnaVJLDGRdNhQmFaAqd7tkKSMGA==
+  dependencies:
+    bl "^4.0.2"
+    debug "^4.1.1"
+    process-nextick-args "^2.0.1"
+
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
@@ -4792,17 +5229,22 @@ ms@2.1.2:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
-ms@^2.0.0, ms@^2.1.1:
+ms@2.1.3, ms@^2.0.0, ms@^2.1.1:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
+
+nanoid@^3.3.1:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.2.tgz#c89622fafb4381cd221421c69ec58547a1eec557"
+  integrity sha512-CuHBogktKwpm5g2sRgv83jEy2ijFzBwMoYA60orPDR7ynsLijJDqgsi4RDGj3OJpy3Ieb+LYwiRmIOGyytgITA==
 
 natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
 
-negotiator@^0.6.3:
+negotiator@0.6.3, negotiator@^0.6.3:
   version "0.6.3"
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.3.tgz#58e323a72fedc0d6f9cd4d31fe49f51479590ccd"
   integrity sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==
@@ -5008,6 +5450,11 @@ nwsapi@^2.2.0:
   resolved "https://registry.yarnpkg.com/nwsapi/-/nwsapi-2.2.0.tgz#204879a9e3d068ff2a55139c2c772780681a38b7"
   integrity sha512-h2AatdwYH+JHiZpv7pt/gSX1XoRGb7L/qSIeuqA6GwYoF9w1vP1cw42TO0aI2pNyshRK5893hNSl+1//vHK7hQ==
 
+object-assign@^4:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
+  integrity sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
+
 object-inspect@^1.11.0, object-inspect@^1.9.0:
   version "1.12.0"
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.12.0.tgz#6e2c120e868fd1fd18cb4f18c31741d0d6e776f0"
@@ -5041,6 +5488,13 @@ obliterator@^1.6.1:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/obliterator/-/obliterator-1.6.1.tgz#dea03e8ab821f6c4d96a299e17aef6a3af994ef3"
   integrity sha512-9WXswnqINnnhOG/5SLimUlzuU1hFJUc8zkwyD59Sd+dPOMf05PmnYG/d6Q7HZ+KmgkZJa1PxRso6QdM3sTNHig==
+
+on-finished@~2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/on-finished/-/on-finished-2.3.0.tgz#20f1336481b083cd75337992a16971aa2d906947"
+  integrity sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=
+  dependencies:
+    ee-first "1.1.1"
 
 once@^1.3.0, once@^1.3.1, once@^1.4.0:
   version "1.4.0"
@@ -5223,6 +5677,11 @@ parse5@6.0.1:
   resolved "https://registry.yarnpkg.com/parse5/-/parse5-6.0.1.tgz#e1a1c085c569b3dc08321184f19a39cc27f7c30b"
   integrity sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==
 
+parseurl@~1.3.3:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/parseurl/-/parseurl-1.3.3.tgz#9da19e7bee8d12dff0513ed5b76957793bc2e8d4"
+  integrity sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==
+
 path-exists@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-3.0.0.tgz#ce0ebeaa5f78cb18925ea7d810d7b59b010fd515"
@@ -5247,6 +5706,11 @@ path-parse@^1.0.7:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.7.tgz#fbc114b60ca42b30d9daf5858e4bd68bbedb6735"
   integrity sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==
+
+path-to-regexp@0.1.7:
+  version "0.1.7"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.7.tgz#df604178005f522f15eb4490e7247a1bfaa67f8c"
+  integrity sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=
 
 path-type@^3.0.0:
   version "3.0.0"
@@ -5280,6 +5744,24 @@ pify@^3.0.0:
   resolved "https://registry.yarnpkg.com/pify/-/pify-3.0.0.tgz#e5a4acd2c101fdf3d9a4d07f0dbc4db49dd28176"
   integrity sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=
 
+pino-std-serializers@^3.1.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/pino-std-serializers/-/pino-std-serializers-3.2.0.tgz#b56487c402d882eb96cd67c257868016b61ad671"
+  integrity sha512-EqX4pwDPrt3MuOAAUBMU0Tk5kR/YcCM5fNPEzgCO2zJ5HfX0vbiH9HbJglnyeQsN96Kznae6MWD47pZB5avTrg==
+
+pino@^6.13.0:
+  version "6.14.0"
+  resolved "https://registry.yarnpkg.com/pino/-/pino-6.14.0.tgz#b745ea87a99a6c4c9b374e4f29ca7910d4c69f78"
+  integrity sha512-iuhEDel3Z3hF9Jfe44DPXR8l07bhjuFY3GMHIXbjnY9XcafbyDDwl2sN2vw2GjMPf5Nkoe+OFao7ffn9SXaKDg==
+  dependencies:
+    fast-redact "^3.0.0"
+    fast-safe-stringify "^2.0.8"
+    flatstr "^1.0.12"
+    pino-std-serializers "^3.1.0"
+    process-warning "^1.0.0"
+    quick-format-unescaped "^4.0.3"
+    sonic-boom "^1.0.2"
+
 pirates@^4.0.4:
   version "4.0.5"
   resolved "https://registry.yarnpkg.com/pirates/-/pirates-4.0.5.tgz#feec352ea5c3268fb23a37c702ab1699f35a5f3b"
@@ -5291,6 +5773,15 @@ pkg-dir@^4.2.0:
   integrity sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==
   dependencies:
     find-up "^4.0.0"
+
+portfinder@^1.0.25:
+  version "1.0.28"
+  resolved "https://registry.yarnpkg.com/portfinder/-/portfinder-1.0.28.tgz#67c4622852bd5374dd1dd900f779f53462fac778"
+  integrity sha512-Se+2isanIcEqf2XMHjyUKskczxbPH7dQnlMjXX6+dybayyHvAf/TCgyMRlzf/B6QDhAEFOGes0pzRo3by4AbMA==
+  dependencies:
+    async "^2.6.2"
+    debug "^3.1.1"
+    mkdirp "^0.5.5"
 
 prelude-ls@^1.2.1:
   version "1.2.1"
@@ -5321,10 +5812,15 @@ proc-log@^2.0.0:
   resolved "https://registry.yarnpkg.com/proc-log/-/proc-log-2.0.0.tgz#25f8cb346a5d08e27f2422b3ca6ba8379bcbf8ba"
   integrity sha512-I/35MfCX2H8jBUhKN8JB8nmqvQo/nKdrBodBY7L3RhDSPPyvOHwLYNmPuhwuJq7a7C3vgFKWGQM+ecPStcvOHA==
 
-process-nextick-args@~2.0.0:
+process-nextick-args@^2.0.1, process-nextick-args@~2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"
   integrity sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==
+
+process-warning@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/process-warning/-/process-warning-1.0.0.tgz#980a0b25dc38cd6034181be4b7726d89066b4616"
+  integrity sha512-du4wfLyj4yCZq1VupnVSZmRsPJsNuxoDQFdCFHLaYiEbFBD7QE0a+I4D7hOxrVnh78QE/YipFAj9lXHiXocV+Q==
 
 progress@^2.0.3:
   version "2.0.3"
@@ -5362,6 +5858,13 @@ promise-retry@^2.0.1:
     err-code "^2.0.2"
     retry "^0.12.0"
 
+promise-toolbox@^0.20.0:
+  version "0.20.0"
+  resolved "https://registry.yarnpkg.com/promise-toolbox/-/promise-toolbox-0.20.0.tgz#af04d7338038c2362b8fb7c27546c57d893bf562"
+  integrity sha512-VXF6waqUheD19yOU7zxsXhw/HCKlXqXwUc4jM8mchtBqZFNA+GHA7dbJsQDLHP4IUpQuTLpCQRd0lCr5z4CqXQ==
+  dependencies:
+    make-error "^1.3.2"
+
 prompts@^2.0.1, prompts@^2.4.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/prompts/-/prompts-2.4.2.tgz#7b57e73b3a48029ad10ebd44f74b01722a4cb069"
@@ -5369,6 +5872,14 @@ prompts@^2.0.1, prompts@^2.4.2:
   dependencies:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
+
+proxy-addr@~2.0.7:
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/proxy-addr/-/proxy-addr-2.0.7.tgz#f19fe69ceab311eeb94b42e70e8c2070f9ba1025"
+  integrity sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==
+  dependencies:
+    forwarded "0.2.0"
+    ipaddr.js "1.9.1"
 
 psl@^1.1.33:
   version "1.8.0"
@@ -5405,6 +5916,16 @@ q@^1.5.1:
   resolved "https://registry.yarnpkg.com/q/-/q-1.5.1.tgz#7e32f75b41381291d04611f1bf14109ac00651d7"
   integrity sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=
 
+qlobber@3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/qlobber/-/qlobber-3.1.0.tgz#b8c8e067496de17bdbf3cd843cf53ece09c8d211"
+  integrity sha512-B7EU6Hv9g4BeJiB7qtOjn9wwgqVpcWE5c4/86O0Yoj7fmAvgwXrdG1E+QF13S/+TX5XGUl7toizP0gzXR2Saug==
+
+qs@6.9.7:
+  version "6.9.7"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.9.7.tgz#4610846871485e1e048f44ae3b94033f0e675afe"
+  integrity sha512-IhMFgUmuNpyRfxA90umL7ByLlgRXu6tIfKPpF5TmcfRLlLCckfP/g3IQmju6jjpu+Hh8rA+2p6A27ZSPOOHdKw==
+
 querystring@0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"
@@ -5415,10 +5936,30 @@ queue-microtask@^1.2.2:
   resolved "https://registry.yarnpkg.com/queue-microtask/-/queue-microtask-1.2.3.tgz#4929228bbc724dfac43e0efb058caf7b6cfb6243"
   integrity sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==
 
+quick-format-unescaped@^4.0.3:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz#93ef6dd8d3453cbc7970dd614fad4c5954d6b5a7"
+  integrity sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==
+
 quick-lru@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-4.0.1.tgz#5b8878f113a58217848c6482026c73e1ba57727f"
   integrity sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==
+
+range-parser@~1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.1.tgz#3cf37023d199e1c24d1a55b84800c2f3e6468031"
+  integrity sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==
+
+raw-body@2.4.3:
+  version "2.4.3"
+  resolved "https://registry.yarnpkg.com/raw-body/-/raw-body-2.4.3.tgz#8f80305d11c2a0a545c2d9d89d7a0286fcead43c"
+  integrity sha512-UlTNLIcu0uzb4D2f4WltY6cVjLi+/jEN4lgEUj3E04tpMDpUlkBo/eSn6zou9hum2VMNpCCUone0O0WeJim07g==
+  dependencies:
+    bytes "3.1.2"
+    http-errors "1.8.1"
+    iconv-lite "0.4.24"
+    unpipe "1.0.0"
 
 rc-config-loader@^4.0.0:
   version "4.0.0"
@@ -5499,7 +6040,7 @@ read-pkg@^5.2.0:
     parse-json "^5.0.0"
     type-fest "^0.6.0"
 
-readable-stream@3, readable-stream@^3.0.0, readable-stream@^3.0.2, readable-stream@^3.6.0:
+readable-stream@3, readable-stream@^3.0.0, readable-stream@^3.0.2, readable-stream@^3.4.0, readable-stream@^3.6.0:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.0.tgz#337bbda3adc0706bd3e024426a286d4b4b2c9198"
   integrity sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==
@@ -5508,7 +6049,7 @@ readable-stream@3, readable-stream@^3.0.0, readable-stream@^3.0.2, readable-stre
     string_decoder "^1.1.1"
     util-deprecate "^1.0.1"
 
-readable-stream@~2.3.6:
+readable-stream@^2.0.0, readable-stream@~2.3.6:
   version "2.3.7"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.7.tgz#1eca1cf711aef814c04f62252a36a62f6cb23b57"
   integrity sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==
@@ -5608,12 +6149,17 @@ responselike@^1.0.2:
   dependencies:
     lowercase-keys "^1.0.0"
 
+retimer@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/retimer/-/retimer-2.0.0.tgz#e8bd68c5e5a8ec2f49ccb5c636db84c04063bbca"
+  integrity sha512-KLXY85WkEq2V2bKex/LOO1ViXVn2KGYe4PYysAdYdjmraYIUsVkXu8O4am+8+5UbaaGl1qho4aqAAPHNQ4GSbg==
+
 retry@^0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/retry/-/retry-0.12.0.tgz#1b42a6266a21f07421d1b0b54b7dc167b01c013b"
   integrity sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=
 
-reusify@^1.0.4:
+reusify@^1.0.0, reusify@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.0.4.tgz#90da382b1e126efc02146e90845a88db12925d76"
   integrity sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==
@@ -5632,15 +6178,15 @@ run-parallel@^1.1.9:
   dependencies:
     queue-microtask "^1.2.2"
 
+safe-buffer@5.2.1, safe-buffer@^5.1.1, safe-buffer@~5.2.0:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
+  integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
+
 safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
   integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
-
-safe-buffer@~5.2.0:
-  version "5.2.1"
-  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
-  integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
 
 "safer-buffer@>= 2.1.2 < 3", "safer-buffer@>= 2.1.2 < 3.0.0":
   version "2.1.2"
@@ -5693,10 +6239,44 @@ semver@^6.0.0, semver@^6.2.0, semver@^6.3.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
 
+send@0.17.2:
+  version "0.17.2"
+  resolved "https://registry.yarnpkg.com/send/-/send-0.17.2.tgz#926622f76601c41808012c8bf1688fe3906f7820"
+  integrity sha512-UJYB6wFSJE3G00nEivR5rgWp8c2xXvJ3OPWPhmuteU0IKj8nKbG3DrjiOmLwpnHGYWAVwA69zmTm++YG0Hmwww==
+  dependencies:
+    debug "2.6.9"
+    depd "~1.1.2"
+    destroy "~1.0.4"
+    encodeurl "~1.0.2"
+    escape-html "~1.0.3"
+    etag "~1.8.1"
+    fresh "0.5.2"
+    http-errors "1.8.1"
+    mime "1.6.0"
+    ms "2.1.3"
+    on-finished "~2.3.0"
+    range-parser "~1.2.1"
+    statuses "~1.5.0"
+
+serve-static@1.14.2:
+  version "1.14.2"
+  resolved "https://registry.yarnpkg.com/serve-static/-/serve-static-1.14.2.tgz#722d6294b1d62626d41b43a013ece4598d292bfa"
+  integrity sha512-+TMNA9AFxUEGuC0z2mevogSnn9MXKb4fa7ngeRMJaaGv8vTwnIEkKi+QGvPt33HSnf8pRS+WGM0EbMtCJLKMBQ==
+  dependencies:
+    encodeurl "~1.0.2"
+    escape-html "~1.0.3"
+    parseurl "~1.3.3"
+    send "0.17.2"
+
 set-blocking@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
   integrity sha1-BF+XgtARrppoA93TgrJDkrPYkPc=
+
+setprototypeof@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.2.0.tgz#66c9a24a73f9fc28cbe66b09fed3d33dcaf1b424"
+  integrity sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==
 
 shebang-command@^2.0.0:
   version "2.0.0"
@@ -5772,6 +6352,14 @@ socks@^2.6.1:
   dependencies:
     ip "^1.1.5"
     smart-buffer "^4.2.0"
+
+sonic-boom@^1.0.2:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/sonic-boom/-/sonic-boom-1.4.1.tgz#d35d6a74076624f12e6f917ade7b9d75e918f53e"
+  integrity sha512-LRHh/A8tpW7ru89lrlkU4AszXt1dbwSjVWguGrmlxE7tawVmDBlI1PILMkXAxJTwqhgsEeTHzj36D5CmHgQmNg==
+  dependencies:
+    atomic-sleep "^1.0.0"
+    flatstr "^1.0.12"
 
 source-map-support@^0.5.21, source-map-support@^0.5.6:
   version "0.5.21"
@@ -5880,6 +6468,27 @@ standard-version@^9:
     semver "^7.1.1"
     stringify-package "^1.0.1"
     yargs "^16.0.0"
+
+"statuses@>= 1.5.0 < 2", statuses@~1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.5.0.tgz#161c7dac177659fd9811f43771fa99381478628c"
+  integrity sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=
+
+steed@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/steed/-/steed-1.1.3.tgz#f1525dd5adb12eb21bf74749537668d625b9abc5"
+  integrity sha1-8VJd1a2xLrIb90dJU3Zo1iW5q8U=
+  dependencies:
+    fastfall "^1.5.0"
+    fastparallel "^2.2.0"
+    fastq "^1.3.0"
+    fastseries "^1.7.0"
+    reusify "^1.0.0"
+
+stream-shift@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/stream-shift/-/stream-shift-1.0.1.tgz#d7088281559ab2778424279b0877da3c392d5a3d"
+  integrity sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==
 
 string-length@^4.0.1:
   version "4.0.2"
@@ -6055,7 +6664,7 @@ throat@^6.0.1:
   resolved "https://registry.yarnpkg.com/throat/-/throat-6.0.1.tgz#d514fedad95740c12c2d7fc70ea863eb51ade375"
   integrity sha512-8hmiGIJMDlwjg7dlJ4yKGLK8EsYqKgPWbG3b4wjJddKNwc7N7Dpn08Df4szr/sZdMVeOstrdYSsqzX6BYbcB+w==
 
-through2@^2.0.0:
+through2@^2.0.0, through2@^2.0.1:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/through2/-/through2-2.0.5.tgz#01c1e39eb31d07cb7d03a96a70823260b23132cd"
   integrity sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==
@@ -6096,6 +6705,11 @@ to-regex-range@^5.0.1:
   integrity sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==
   dependencies:
     is-number "^7.0.0"
+
+toidentifier@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.1.tgz#3be34321a88a820ed1bd80dfaa33e479fbb8dd35"
+  integrity sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==
 
 tough-cookie@^4.0.0:
   version "4.0.0"
@@ -6179,7 +6793,7 @@ tslib@^1.11.1, tslib@^1.8.1:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@^2.3.0:
+tslib@^2.3.0, tslib@~2.3.0:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
   integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
@@ -6234,6 +6848,14 @@ type-fest@^0.8.1:
   version "0.8.1"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.8.1.tgz#09e249ebde851d3b1e48d27c105444667f17b83d"
   integrity sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==
+
+type-is@~1.6.18:
+  version "1.6.18"
+  resolved "https://registry.yarnpkg.com/type-is/-/type-is-1.6.18.tgz#4e552cd05df09467dcbc4ef739de89f2cf37c131"
+  integrity sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==
+  dependencies:
+    media-typer "0.3.0"
+    mime-types "~2.1.24"
 
 typedarray-to-buffer@^3.1.5:
   version "3.1.5"
@@ -6311,6 +6933,11 @@ universalify@^2.0.0:
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-2.0.0.tgz#75a4984efedc4b08975c5aeb73f530d02df25717"
   integrity sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==
 
+unpipe@1.0.0, unpipe@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/unpipe/-/unpipe-1.0.0.tgz#b2bf4ee8514aae6165b4817829d21b2ef49904ec"
+  integrity sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=
+
 update-notifier@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/update-notifier/-/update-notifier-5.1.0.tgz#4ab0d7c7f36a231dd7316cf7729313f0214d9ad9"
@@ -6358,6 +6985,11 @@ util-deprecate@^1.0.1, util-deprecate@~1.0.1:
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=
 
+utils-merge@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
+  integrity sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=
+
 uuid@3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
@@ -6401,6 +7033,16 @@ validate-npm-package-name@^3.0.0:
   integrity sha1-X6kS2B630MdK/BQN5zF/DKffQ34=
   dependencies:
     builtins "^1.0.3"
+
+value-or-promise@1.0.11:
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/value-or-promise/-/value-or-promise-1.0.11.tgz#3e90299af31dd014fe843fe309cefa7c1d94b140"
+  integrity sha512-41BrgH+dIbCFXClcSapVs5M6GkENd3gQOJpEfPDNa71LsUGMXDL0jMWpI/Rh7WhX+Aalfz2TTS3Zt5pUsbnhLg==
+
+vary@^1, vary@~1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
+  integrity sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=
 
 w3c-hr-time@^1.0.2:
   version "1.0.2"
@@ -6527,7 +7169,7 @@ write-file-atomic@^3.0.0:
     signal-exit "^3.0.2"
     typedarray-to-buffer "^3.1.5"
 
-ws@^7.4.6:
+ws@^7.4.6, ws@^7.5.7:
   version "7.5.7"
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.7.tgz#9e0ac77ee50af70d58326ecff7e85eb3fa375e67"
   integrity sha512-KMvVuFzpKBuiIXW3E4u3mySRO2/mCHSyZDJQM5NQ9Q9KHWHWh0NHgfbRMLLrceUK5qAL4ytALJbpRMjixFZh8A==
@@ -6576,7 +7218,7 @@ xmlchars@^2.2.0:
   resolved "https://registry.yarnpkg.com/xmlchars/-/xmlchars-2.2.0.tgz#060fe1bcb7f9c76fe2a17db86a9bc3ab894210cb"
   integrity sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==
 
-xtend@~4.0.1:
+xtend@^4.0.0, xtend@^4.0.2, xtend@~4.0.1:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.2.tgz#bb72779f5fa465186b1f438f674fa347fdb5db54"
   integrity sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==


### PR DESCRIPTION
Closes #91,  Closes #93
Part of #48 (missing the ability to send an event from a step function)


* [x] Change node === undefined to return undefined identity and not UndefinedExpression
* [x] Change SFN to accept an object and not an array of parameters
* [x] Change argument expression to be maybe undefined
* [x] Add ability to pipe to Event Bridge
* [x] Reference data outside of the event bus closures (`map` and `when`)
* [ ] Add ability to send event bridge notification in step functions

### Before Step Functions Parameter change

```ts
const func = new StepFunction((arg1: string, arg2: string): string => { return arg1 + arg2; });

// in app sync
const result = func("hello", "world");
```

### After Step Functions Parameter change #91

```ts
const func = new StepFunction<{ arg1: string, arg2: string}, string>((input)=> { return input.arg1 + input.arg2; });

// in app sync
const result = func({ arg1: "hello", arg2: "world"});

new EventBus().when().map(event => ({ arg1: event.id, arg2: "world" }).pipe(func );
```

### Support Invoking Step Functions From Event Bridge Events #48 

```ts
const myFunction = new StepFunction();

new EventBus().when(...).map(...).pipe(myFunction);
```

### Event Bridge Support Outside Constants #93

```ts
const stepFunction = new StepFunction();
const testSource = "someSource";

new EventBridge().when(event => event.resources.includes(stepFunction.stepFunctionArn) && event.source === testSource);
```

BREAKING CHANGE: Change to the signature of `StepFunction` and `ExpressStepFunction`.  Step Functions accept an `Input` object and a `Output` object type parameter. The input type is given to the StepFunction function as a single Object instead of an array of parameters.

