### PR TITLE
feat(event-bridge, step-functions): step functions put event bridge events

### DIFF
--- a/src/compile.ts
+++ b/src/compile.ts
@@ -803,7 +803,7 @@ export function compile(
                 symbol.valueDeclaration.initializer &&
                 !hasParent(symbol.valueDeclaration, scope)
               ) {
-                return ref(symbol.valueDeclaration.initializer);
+                return ref(ts.factory.createIdentifier(symbol.name));
               }
             }
           }

--- a/src/event-bridge/event-bus.ts
+++ b/src/event-bridge/event-bus.ts
@@ -102,7 +102,7 @@ export interface IEventBus<E extends EventBusRuleInput> {
   /**
    * Put one or more events on an Event Bus.
    */
-  (...events: Partial<E>[]): void;
+  (event: Partial<E>, ...events: Partial<E>[]): void;
 }
 abstract class EventBusBase<E extends EventBusRuleInput>
   implements IEventBus<E>

--- a/src/event-bridge/event-bus.ts
+++ b/src/event-bridge/event-bus.ts
@@ -121,15 +121,13 @@ abstract class EventBusBase<E extends EventBusRuleInput>
       if (isASL(context)) {
         this.bus.grantPutEventsTo(context.role);
 
-        // Lets validate and normalize that the events are
+        // Validate that the events are object literals.
+        // Then normalize nested arrays of events into a single list of events.
+        // TODO Relax these restrictions: https://github.com/sam-goodwin/functionless/issues/101 
         const eventObjs = call.args.reduce(
           (events: ObjectLiteralExpr[], arg) => {
             if (isArrayLiteralExpr(arg.expr)) {
-              if (
-                !arg.expr.items.every((item): item is ObjectLiteralExpr =>
-                  isObjectLiteralExpr(item)
-                )
-              ) {
+              if (!arg.expr.items.every(isObjectLiteralExpr)) {
                 throw Error(
                   "Event Bus put events must use inline object parameters. Variable references are not supported currently."
                 );


### PR DESCRIPTION
Closes #48

Event Bridge Put Events API is one of the methods for putting new events on an event bus. We support some first party integrations between services and event bus.

Support (See issues for progress):
* Step Functions
* App Sync (coming soon #53)
* API Gateway (coming soon #50)

```ts
bus = new EventBus(stack, "bus");
new StepFunction<{ value: string }, void>((input) => {
  bus({
    detail: {
      value: input.value,
    },
  });
});
```

This will create a step function which sends an event. It is also possible to send multiple events and use other Step Function logic.

> Limit: It is not currently possible to dynamically generate different numbers of events. All events sent must start from objects in the form `{ detail: ..., source: ... }` where all fields are optional.