### PR TITLE
feat: step functions event source, `when` refining, `when` and `map` narrowing 

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,6 +372,13 @@ const catPeopleEvents = bus.when(
 );
 ```
 
+Rules can be further refined by chaining multiple `when` predicates together.
+
+```ts
+// Cat people who are between 18 and 30 and do not also like dogs.
+catPeopleEvents.when(event => !event.detail.interests.includes("DOGS"))
+```
+
 #### Transform the event before sending to some services like `Lambda` Functions.
 
 We have two lambda functions to invoke, one for create or updates and another for deletes, lets make those.

--- a/README.md
+++ b/README.md
@@ -372,7 +372,7 @@ const catPeopleEvents = bus.when(
 );
 ```
 
-Rules can be further refined by chaining multiple `when` predicates together.
+Rules can be further refined by calling `when` on a Functionless `EventBusRule`.
 
 ```ts
 // Cat people who are between 18 and 30 and do not also like dogs.

--- a/src/compile.ts
+++ b/src/compile.ts
@@ -751,6 +751,9 @@ export function compile(
           return toExpr(node.expression, scope);
         } else if (ts.isNonNullExpression(node)) {
           return toExpr(node.expression, scope);
+        } else if (node.kind === ts.SyntaxKind.ThisKeyword) {
+          // assuming that this is used in a valid location, create a closure around that instance.
+          return ref(ts.factory.createIdentifier("this"));
         }
 
         throw new Error(

--- a/src/compile.ts
+++ b/src/compile.ts
@@ -86,7 +86,7 @@ export function compile(
             );
           } else if (isEventBusWhenFunction(node)) {
             return visitEventBusWhen(node);
-          } else if (isEventBusMapFunction(node)) {
+          } else if (isEventBusRuleMapFunction(node)) {
             return visitEventBusMap(node);
           } else if (isNewEventBusRule(node)) {
             return visitEventBusRule(node);
@@ -185,11 +185,12 @@ export function compile(
           ts.isCallExpression(node) &&
           ts.isPropertyAccessExpression(node.expression) &&
           node.expression.name.text === "when" &&
-          isEventBus(node.expression.expression)
+          (isEventBus(node.expression.expression) ||
+            isEventBusRule(node.expression.expression))
         );
       }
 
-      function isEventBusMapFunction(
+      function isEventBusRuleMapFunction(
         node: ts.Node
       ): node is EventBusMapInterface {
         return (

--- a/src/compile.ts
+++ b/src/compile.ts
@@ -803,7 +803,7 @@ export function compile(
                 symbol.valueDeclaration.initializer &&
                 !hasParent(symbol.valueDeclaration, scope)
               ) {
-                return ref(symbol.valueDeclaration.initializer);
+                return ref(ts.factory.createIdentifier(symbol.name));
               }
             }
           }

--- a/src/compile.ts
+++ b/src/compile.ts
@@ -168,16 +168,29 @@ export function compile(
         arguments: [TsFunctionParameter];
       };
 
+      /**
+       * Matches the patterns:
+       *   * new EventBusRule()
+       */
       function isNewEventBusRule(node: ts.Node): node is EventBusRuleInterface {
         return ts.isNewExpression(node) && isEventBusRule(node.expression);
       }
 
+      /**
+       * Matches the patterns:
+       *   * new EventBusTransform()
+       */
       function isNewEventBusTransform(
         node: ts.Node
       ): node is EventBusTransformInterface {
         return ts.isNewExpression(node) && isEventBusTransform(node.expression);
       }
 
+      /**
+       * Matches the patterns:
+       *   * IEventBus.when
+       *   * IEventBusRule.when
+       */
       function isEventBusWhenFunction(
         node: ts.Node
       ): node is EventBusWhenInterface {
@@ -190,6 +203,10 @@ export function compile(
         );
       }
 
+      /**
+       * Matches the patterns:
+       *   * IEventBusRule.map()
+       */
       function isEventBusRuleMapFunction(
         node: ts.Node
       ): node is EventBusMapInterface {
@@ -204,6 +221,9 @@ export function compile(
       /**
        * Checks to see if a node is of type EventBus.
        * The node could be any kind of node that returns an event bus rule.
+       * 
+       * Matches the patterns:
+       *   * IEventBus
        */
       function isEventBus(node: ts.Node) {
         return isFunctionlessClassOfKind(node, EventBus.FunctionlessType);
@@ -212,7 +232,10 @@ export function compile(
       /**
        * Checks to see if a node is of type {@link EventBusRule}.
        * The node could be any kind of node that returns an event bus rule.
-       */
+       * 
+       * Matches the patterns:
+       *   * IEventBusRule
+      */
       function isEventBusRule(node: ts.Node) {
         return isFunctionlessClassOfKind(node, EventBusRule.FunctionlessType);
       }
@@ -220,6 +243,9 @@ export function compile(
       /**
        * Checks to see if a node is of type {@link EventBusTransform}.
        * The node could be any kind of node that returns an event bus rule.
+       * 
+       * Matches the patterns:
+       *   * IEventBusTransform
        */
       function isEventBusTransform(node: ts.Node) {
         return isFunctionlessClassOfKind(

--- a/src/event-bridge/event-bus.ts
+++ b/src/event-bridge/event-bus.ts
@@ -102,7 +102,7 @@ export interface IEventBus<E extends EventBusRuleInput> {
   /**
    * Put one or more events on an Event Bus.
    */
-  (...events: Partial<E>[]): void;
+  (event: Partial<E>, ...events: Partial<E>[]): void;
 }
 abstract class EventBusBase<E extends EventBusRuleInput>
   implements IEventBus<E>

--- a/src/event-bridge/event-bus.ts
+++ b/src/event-bridge/event-bus.ts
@@ -16,7 +16,7 @@ import {
   PropAssignExpr,
   StringLiteralExpr,
 } from "../expression";
-import { EventBusRule, EventPredicateFunction, IEventBusRule } from "./rule";
+import { EventBusRule, EventPredicateFunction } from "./rule";
 import { EventBusRuleInput } from "./types";
 
 export const isEventBus = <E extends EventBusRuleInput>(
@@ -28,14 +28,7 @@ export const isEventBus = <E extends EventBusRuleInput>(
   );
 };
 
-export interface IEventBus<E extends EventBusRuleInput> {
-  readonly bus: aws_events.IEventBus;
-
-  /**
-   * This static property identifies this class as an EventBus to the TypeScript plugin.
-   */
-  readonly functionlessKind: typeof EventBusBase.FunctionlessType;
-
+export interface IEventBusFilterable<E extends EventBusRuleInput> {
   /**
    * EventBus Rules can filter events using Functionless predicate functions.
    *
@@ -98,6 +91,16 @@ export interface IEventBus<E extends EventBusRuleInput> {
     id: string,
     predicate: EventPredicateFunction<E>
   ): EventBusRule<E>;
+}
+
+export interface IEventBus<E extends EventBusRuleInput>
+  extends IEventBusFilterable<E> {
+  readonly bus: aws_events.IEventBus;
+
+  /**
+   * This static property identifies this class as an EventBus to the TypeScript plugin.
+   */
+  readonly functionlessKind: typeof EventBusBase.FunctionlessType;
 
   /**
    * Put one or more events on an Event Bus.
@@ -222,7 +225,7 @@ abstract class EventBusBase<E extends EventBusRuleInput>
     scope: Construct,
     id: string,
     predicate: EventPredicateFunction<E>
-  ): IEventBusRule<E> {
+  ): EventBusRule<E> {
     return new EventBusRule<E>(scope, id, this, predicate);
   }
 }

--- a/src/event-bridge/event-bus.ts
+++ b/src/event-bridge/event-bus.ts
@@ -121,15 +121,13 @@ abstract class EventBusBase<E extends EventBusRuleInput>
       if (isASL(context)) {
         this.bus.grantPutEventsTo(context.role);
 
-        // Lets validate and normalize that the events are
+        // Validate that the events are object literals.
+        // Then normalize nested arrays of events into a single list of events.
+        // TODO Relax these restrictions: https://github.com/sam-goodwin/functionless/issues/101 
         const eventObjs = call.args.reduce(
           (events: ObjectLiteralExpr[], arg) => {
             if (isArrayLiteralExpr(arg.expr)) {
-              if (
-                !arg.expr.items.every((item): item is ObjectLiteralExpr =>
-                  isObjectLiteralExpr(item)
-                )
-              ) {
+              if (!arg.expr.items.every(isObjectLiteralExpr)) {
                 throw Error(
                   "Event Bus put events must use inline object parameters. Variable references are not supported currently."
                 );

--- a/src/event-bridge/event-bus.ts
+++ b/src/event-bridge/event-bus.ts
@@ -86,14 +86,14 @@ export interface IEventBusFilterable<E extends EventBusRuleInput> {
    * Unsupported by Functionless:
    * * Variables from outside of the function scope
    */
-  when(
+  when<O extends E>(
     scope: Construct,
     id: string,
-    predicate: EventPredicateFunction<E>
-  ): EventBusRule<E>;
+    predicate: EventPredicateFunction<E, O>
+  ): EventBusRule<E, O>;
 }
 
-export interface IEventBus<E extends EventBusRuleInput>
+export interface IEventBus<E extends EventBusRuleInput = EventBusRuleInput>
   extends IEventBusFilterable<E> {
   readonly bus: aws_events.IEventBus;
 
@@ -221,12 +221,12 @@ abstract class EventBusBase<E extends EventBusRuleInput>
   /**
    * @inheritdoc
    */
-  when(
+  when<O extends E>(
     scope: Construct,
     id: string,
-    predicate: EventPredicateFunction<E>
-  ): EventBusRule<E> {
-    return new EventBusRule<E>(scope, id, this, predicate);
+    predicate: EventPredicateFunction<E, O>
+  ): EventBusRule<E, O> {
+    return new EventBusRule<E, O>(scope, id, this as any, predicate);
   }
 }
 
@@ -300,8 +300,8 @@ export class EventBus<E extends EventBusRuleInput> extends EventBusBase<E> {
 
   /**
    * Retrieves the default event bus as a singleton on the given stack or the stack of the given construct.
-   * 
-   * Equivalent to doing 
+   *
+   * Equivalent to doing
    * ```ts
    * const awsBus = aws_events.EventBus.fromEventBusName(Stack.of(scope), id, "default");
    * new functionless.EventBus.fromBus(awsBus);

--- a/src/event-bridge/event-pattern/synth.ts
+++ b/src/event-bridge/event-pattern/synth.ts
@@ -68,6 +68,25 @@ const OPERATIONS = { STARTS_WITH: "startsWith", INCLUDES: "includes" };
 const INCLUDES_SEARCH_ELEMENT = "searchElement";
 const STARTS_WITH_SEARCH_STRING = "searchString";
 
+/**
+ * Turns a pattern document into the Event Bridge Pattern format.
+ * 
+ * To transform from a {@link EventBusPredicateFunction}, first call {@link synthesizePatternDocument}.
+ * 
+ *  {
+ *    doc: {
+ *        source: {
+ *              value: "lambda"
+ *        }
+ *   }
+ * }
+ * 
+ * becomes
+ * 
+ * {
+ *    source: ["lambda"]
+ * }
+ */
 export const synthesizeEventPattern = (
   document: PatternDocument
 ): functionless_event_bridge.FunctionlessEventPattern => {

--- a/src/event-bridge/event-pattern/synth.ts
+++ b/src/event-bridge/event-pattern/synth.ts
@@ -100,11 +100,7 @@ export const synthesizeEventPattern = (
  * https://github.com/sam-goodwin/functionless/issues/37#issuecomment-1066313146
  */
 export const synthesizePatternDocument = (
-  predicate: FunctionDecl | Err | unknown,
-  /**
-   * Document to join (AND) with the predicate.
-   */
-  aggregateDocument?: PatternDocument
+  predicate: FunctionDecl | Err | unknown
 ): PatternDocument => {
   if (isErr(predicate)) {
     throw predicate.error;
@@ -154,223 +150,6 @@ export const synthesizePatternDocument = (
     const right = evalExpr(expr.right);
 
     return andDocuments(left, right);
-  };
-
-  /**
-   * AND logic between two collections of patterns.
-   *
-   * Event bridge suports AND logic between fields
-   *
-   * { field1: Pattern } && { field2: Pattern }
-   * => { field1: Pattern, field2: Pattern }
-   *
-   * When both documents contain the same field, Event bridge may support AND between two patterns on a single field.
-   * See {@link andMergePattern}
-   */
-  const andDocuments = (
-    classDocument1: PatternDocument,
-    classDocument2: PatternDocument
-  ): PatternDocument => {
-    const allKeys = [
-      ...new Set([
-        ...Object.keys(classDocument1.doc),
-        ...Object.keys(classDocument2.doc),
-      ]),
-    ];
-
-    return allKeys.reduce(
-      (doc: PatternDocument, key) => {
-        // if key is only in one document, return it
-        const pattern = !(key in classDocument1.doc)
-          ? classDocument2.doc?.[key]
-          : !(key in classDocument2.doc)
-          ? classDocument1.doc?.[key]
-          : undefined;
-        // if the key is in both documents, try to merge them
-        const mergedPattern =
-          pattern ??
-          andMergePattern(
-            key,
-            classDocument1.doc[key],
-            classDocument2.doc[key]
-          );
-        return {
-          doc: {
-            ...doc.doc,
-            [key]: mergedPattern,
-          },
-        };
-      },
-      { doc: {} }
-    );
-  };
-
-  /**
-   * When applying AND logic between {@link andDocuments} and both documents contain the same field, we attempt to merge them.
-   *
-   * In genral, Event Bridge DOES NOT support AND logic within a single field as a pattern is a array of OR pattern matchers.
-   *
-   * We do, however support a few cases.
-   *    When each field is itself a document, recurse into {@link andDocuments}
-   *       When one is a Document and one is a Pattern, we will fail to merge.
-   *    When each field is the same pattern, return the pattern.
-   *    When one field is a Present (exists: true) Pattern, ignore the check for present. (x && x === "a" => x === "a")
-   *    When one field is a Not Present (exists: false) Pattern and the other is an AnythingBut (not) pattern, we ignore the AnythingBut (!x && !x !== "a" => !x)
-   *    When both fields are numbers or numeric ranges see {@link andNumericAggregation}
-   *    When both fields are AnythingBut (not) logic, merge them together (x !== "y" && x !== "z" is valid)
-   *
-   * When to return NeverPattern and when to Error
-   * * NeverPattern - when the logic is impossible, but valid aka, contradictions x !== "a" && x === "a". These MAY later be evaluated to possible using an OR.
-   * * Error - When the combination is unsupported by Event Bridge or Functionless.
-   *           For example, if we do not know how to represent !x.startsWith("x") && x.startsWith("y"),
-   *           then we need to fail compilation as the logic may filter a event if it was supported and not ignored.
-   */
-  const andMergePattern = (
-    key: string,
-    pattern1: PatternDocument | Pattern,
-    pattern2: PatternDocument | Pattern
-  ): PatternDocument | Pattern => {
-    // both are documents, lets merge the documents
-    if (isPatternDocument(pattern1) && isPatternDocument(pattern2)) {
-      return andDocuments(pattern1, pattern2);
-      // both are patterns, merge the patterns
-    } else if (!isPatternDocument(pattern1) && !isPatternDocument(pattern2)) {
-      // In AND logic, if either side is impossible, the whole statement will be impossible.
-      if (isNeverPattern(pattern1)) {
-        return pattern1;
-      } else if (isNeverPattern(pattern2)) {
-        return pattern2;
-      } else if (isPresentPattern(pattern1)) {
-        if (isPresentPattern(pattern2)) {
-          // same pattern, merge
-          if (pattern1.isPresent === pattern2.isPresent) {
-            return pattern1;
-          } else {
-            return {
-              never: true,
-              reason: "Field cannot both be present and not present.",
-            };
-          }
-        }
-        // If the pattern checks for presense, return othe other pattern, they should all imply the pattern is present.
-        else if (pattern1.isPresent) {
-          return pattern2;
-        }
-        // checks for not present
-        // take anything but, because !x && x !== "x" => !x
-        else if (isAnythingButPattern(pattern2)) {
-          return pattern1;
-        }
-        // cannot && exists: false and any other pattern as it would be impossible.
-        return {
-          never: true,
-          reason:
-            "Invalid comparison: pattern cannot both be not present as a positive value.",
-        };
-      } else if (isPresentPattern(pattern2)) {
-        // If the pattern checks for presense, return othe other pattern, they should all imply the pattern is present.
-        if (pattern2.isPresent) {
-          return pattern1;
-        }
-        // checks for not present
-        // take anything but, because !x && x !== "x" => !x
-        else if (isAnythingButPattern(pattern1)) {
-          return pattern2;
-        }
-        // cannot && exists: false and any other pattern as it would be impossible.
-        return {
-          never: true,
-          reason:
-            "Invalid comparison: pattern cannot both be not present as a positive value.",
-        };
-      }
-      // AND (intersect) logic between two numeric aggregate ranges (unions), between a numeric aggregate and a single numeric range or between two numeric ranges
-      else if (isNumericAggregationPattern(pattern1)) {
-        if (isNumericAggregationPattern(pattern2)) {
-          return intersectNumericAggregation(pattern1, pattern2);
-        } else if (isNumericRangePattern(pattern2)) {
-          return intersectNumericAggregationWithRange(pattern1, pattern2);
-        }
-      } else if (isNumericAggregationPattern(pattern2)) {
-        if (isNumericRangePattern(pattern1)) {
-          return intersectNumericAggregationWithRange(pattern2, pattern1);
-        }
-      } else if (
-        isNumericRangePattern(pattern1) &&
-        isNumericRangePattern(pattern2)
-      ) {
-        return intersectNumericRange(pattern1, pattern2);
-      }
-      // AND logic between anything but (not equals) patterns
-      else if (isAnythingButPattern(pattern1)) {
-        if (isAnythingButPattern(pattern2)) {
-          return {
-            anythingBut: [...pattern1.anythingBut, ...pattern2.anythingBut],
-          };
-        }
-      }
-      if (
-        isAnythingButPrefixPattern(pattern1) ||
-        isAnythingButPrefixPattern(pattern2)
-      ) {
-        if (
-          isAnythingButPrefixPattern(pattern1) &&
-          isAnythingButPrefixPattern(pattern2) &&
-          pattern1.anythingButPrefix === pattern2.anythingButPrefix
-        ) {
-          return pattern1;
-        }
-        throw Error(
-          "Event Bridge patterns do not support AND logic between NOT prefix and any other logic."
-        );
-      } else if (
-        isExactMatchPattern(pattern1) ||
-        isExactMatchPattern(pattern2)
-      ) {
-        if (isExactMatchPattern(pattern1) && isExactMatchPattern(pattern2)) {
-          if (pattern1.value === pattern2.value) {
-            return pattern1;
-          }
-          return {
-            never: true,
-            reason: `Field ${key} cannot be both ${pattern1.value} and ${pattern2.value}`,
-          };
-        } else if (isExactMatchPattern(pattern1)) {
-          if (isPrefixMatchPattern(pattern2)) {
-            if (
-              typeof pattern1.value === "string" &&
-              pattern1.value.startsWith(pattern2.prefix)
-            ) {
-              return pattern1;
-            }
-            return {
-              never: true,
-              reason: `Field ${key} cannot be both ${pattern1.value} and start with ${pattern2.prefix}`,
-            };
-          }
-        } else if (isExactMatchPattern(pattern2)) {
-          if (isPrefixMatchPattern(pattern1)) {
-            if (
-              typeof pattern2.value === "string" &&
-              pattern2.value.startsWith(pattern1.prefix)
-            ) {
-              return pattern1;
-            }
-            return {
-              never: true,
-              reason: `Field ${key} cannot be both ${pattern2.value} and start with ${pattern1.prefix}`,
-            };
-          }
-        }
-      }
-      throw new Error(
-        `Cannot apply AND to patterns ${JSON.stringify(
-          pattern1
-        )} and ${JSON.stringify(pattern2)}`
-      );
-    }
-    // we don't know how to do this (yet?)
-    throw new Error(`Patterns of key ${key} defined at different levels.`);
   };
 
   /**
@@ -804,8 +583,8 @@ export const synthesizePatternDocument = (
     ) {
       return eventReferenceToPatternDocument(eventReference, { value });
     }
-    const __exchaustive: never = value;
-    return __exchaustive;
+    const __exhaustive: never = value;
+    return __exhaustive;
   };
 
   const evalNotEquals = (expr: BinaryExpr): PatternDocument => {
@@ -855,11 +634,7 @@ export const synthesizePatternDocument = (
 
   const flattenedExpression = flattenReturnEvent(predicate.body.statements);
 
-  const doc = evalExpr(flattenedExpression);
-  if (aggregateDocument) {
-    return andDocuments(aggregateDocument, doc);
-  }
-  return doc;
+  return evalExpr(flattenedExpression);
 };
 
 /**
@@ -966,4 +741,214 @@ export const invertBinaryOperator = (op: BinaryOp): BinaryOp => {
     default:
       return op;
   }
+};
+
+/**
+ * AND logic between two collections of patterns.
+ *
+ * Event bridge supports AND logic between fields
+ *
+ * { field1: Pattern } && { field2: Pattern }
+ * => { field1: Pattern, field2: Pattern }
+ *
+ * When both documents contain the same field, Event bridge may support AND between two patterns on a single field.
+ * See {@link andMergePattern}
+ */
+export const andDocuments = (
+  classDocument1: PatternDocument,
+  classDocument2: PatternDocument
+): PatternDocument => {
+  const allKeys = [
+    ...new Set([
+      ...Object.keys(classDocument1.doc),
+      ...Object.keys(classDocument2.doc),
+    ]),
+  ];
+
+  return allKeys.reduce(
+    (doc: PatternDocument, key) => {
+      // if key is only in one document, return it
+      const pattern = !(key in classDocument1.doc)
+        ? classDocument2.doc?.[key]
+        : !(key in classDocument2.doc)
+        ? classDocument1.doc?.[key]
+        : undefined;
+      // if the key is in both documents, try to merge them
+      const mergedPattern =
+        pattern ??
+        andMergePattern(key, classDocument1.doc[key], classDocument2.doc[key]);
+      return {
+        doc: {
+          ...doc.doc,
+          [key]: mergedPattern,
+        },
+      };
+    },
+    { doc: {} }
+  );
+};
+
+/**
+ * When applying AND logic between {@link andDocuments} and both documents contain the same field, we attempt to merge them.
+ *
+ * In general, Event Bridge DOES NOT support AND logic within a single field as a pattern is a array of OR pattern matchers.
+ *
+ * We do, however support a few cases.
+ *    When each field is itself a document, recurse into {@link andDocuments}
+ *       When one is a Document and one is a Pattern, we will fail to merge.
+ *    When each field is the same pattern, return the pattern.
+ *    When one field is a Present (exists: true) Pattern, ignore the check for present. (x && x === "a" => x === "a")
+ *    When one field is a Not Present (exists: false) Pattern and the other is an AnythingBut (not) pattern, we ignore the AnythingBut (!x && !x !== "a" => !x)
+ *    When both fields are numbers or numeric ranges see {@link andNumericAggregation}
+ *    When both fields are AnythingBut (not) logic, merge them together (x !== "y" && x !== "z" is valid)
+ *
+ * When to return NeverPattern and when to Error
+ * * NeverPattern - when the logic is impossible, but valid aka, contradictions x !== "a" && x === "a". These MAY later be evaluated to possible using an OR.
+ * * Error - When the combination is unsupported by Event Bridge or Functionless.
+ *           For example, if we do not know how to represent !x.startsWith("x") && x.startsWith("y"),
+ *           then we need to fail compilation as the logic may filter a event if it was supported and not ignored.
+ */
+const andMergePattern = (
+  key: string,
+  pattern1: PatternDocument | Pattern,
+  pattern2: PatternDocument | Pattern
+): PatternDocument | Pattern => {
+  // both are documents, lets merge the documents
+  if (isPatternDocument(pattern1) && isPatternDocument(pattern2)) {
+    return andDocuments(pattern1, pattern2);
+    // both are patterns, merge the patterns
+  } else if (!isPatternDocument(pattern1) && !isPatternDocument(pattern2)) {
+    // In AND logic, if either side is impossible, the whole statement will be impossible.
+    if (isNeverPattern(pattern1)) {
+      return pattern1;
+    } else if (isNeverPattern(pattern2)) {
+      return pattern2;
+    } else if (isPresentPattern(pattern1)) {
+      if (isPresentPattern(pattern2)) {
+        // same pattern, merge
+        if (pattern1.isPresent === pattern2.isPresent) {
+          return pattern1;
+        } else {
+          return {
+            never: true,
+            reason: "Field cannot both be present and not present.",
+          };
+        }
+      }
+      // If the pattern checks for presence, return other pattern, they should all imply the pattern is present.
+      else if (pattern1.isPresent) {
+        return pattern2;
+      }
+      // checks for not present
+      // take anything but, because !x && x !== "x" => !x
+      else if (isAnythingButPattern(pattern2)) {
+        return pattern1;
+      }
+      // cannot && exists: false and any other pattern as it would be impossible.
+      return {
+        never: true,
+        reason:
+          "Invalid comparison: pattern cannot both be not present as a positive value.",
+      };
+    } else if (isPresentPattern(pattern2)) {
+      // If the pattern checks for presence, return other pattern, they should all imply the pattern is present.
+      if (pattern2.isPresent) {
+        return pattern1;
+      }
+      // checks for not present
+      // take anything but, because !x && x !== "x" => !x
+      else if (isAnythingButPattern(pattern1)) {
+        return pattern2;
+      }
+      // cannot && exists: false and any other pattern as it would be impossible.
+      return {
+        never: true,
+        reason:
+          "Invalid comparison: pattern cannot both be not present as a positive value.",
+      };
+    }
+    // AND (intersect) logic between two numeric aggregate ranges (unions), between a numeric aggregate and a single numeric range or between two numeric ranges
+    else if (isNumericAggregationPattern(pattern1)) {
+      if (isNumericAggregationPattern(pattern2)) {
+        return intersectNumericAggregation(pattern1, pattern2);
+      } else if (isNumericRangePattern(pattern2)) {
+        return intersectNumericAggregationWithRange(pattern1, pattern2);
+      }
+    } else if (isNumericAggregationPattern(pattern2)) {
+      if (isNumericRangePattern(pattern1)) {
+        return intersectNumericAggregationWithRange(pattern2, pattern1);
+      }
+    } else if (
+      isNumericRangePattern(pattern1) &&
+      isNumericRangePattern(pattern2)
+    ) {
+      return intersectNumericRange(pattern1, pattern2);
+    }
+    // AND logic between anything but (not equals) patterns
+    else if (isAnythingButPattern(pattern1)) {
+      if (isAnythingButPattern(pattern2)) {
+        return {
+          anythingBut: [...pattern1.anythingBut, ...pattern2.anythingBut],
+        };
+      }
+    }
+    if (
+      isAnythingButPrefixPattern(pattern1) ||
+      isAnythingButPrefixPattern(pattern2)
+    ) {
+      if (
+        isAnythingButPrefixPattern(pattern1) &&
+        isAnythingButPrefixPattern(pattern2) &&
+        pattern1.anythingButPrefix === pattern2.anythingButPrefix
+      ) {
+        return pattern1;
+      }
+      throw Error(
+        "Event Bridge patterns do not support AND logic between NOT prefix and any other logic."
+      );
+    } else if (isExactMatchPattern(pattern1) || isExactMatchPattern(pattern2)) {
+      if (isExactMatchPattern(pattern1) && isExactMatchPattern(pattern2)) {
+        if (pattern1.value === pattern2.value) {
+          return pattern1;
+        }
+        return {
+          never: true,
+          reason: `Field ${key} cannot be both ${pattern1.value} and ${pattern2.value}`,
+        };
+      } else if (isExactMatchPattern(pattern1)) {
+        if (isPrefixMatchPattern(pattern2)) {
+          if (
+            typeof pattern1.value === "string" &&
+            pattern1.value.startsWith(pattern2.prefix)
+          ) {
+            return pattern1;
+          }
+          return {
+            never: true,
+            reason: `Field ${key} cannot be both ${pattern1.value} and start with ${pattern2.prefix}`,
+          };
+        }
+      } else if (isExactMatchPattern(pattern2)) {
+        if (isPrefixMatchPattern(pattern1)) {
+          if (
+            typeof pattern2.value === "string" &&
+            pattern2.value.startsWith(pattern1.prefix)
+          ) {
+            return pattern1;
+          }
+          return {
+            never: true,
+            reason: `Field ${key} cannot be both ${pattern2.value} and start with ${pattern1.prefix}`,
+          };
+        }
+      }
+    }
+    throw new Error(
+      `Cannot apply AND to patterns ${JSON.stringify(
+        pattern1
+      )} and ${JSON.stringify(pattern2)}`
+    );
+  }
+  // we don't know how to do this (yet?)
+  throw new Error(`Patterns of key ${key} defined at different levels.`);
 };

--- a/src/event-bridge/rule.ts
+++ b/src/event-bridge/rule.ts
@@ -260,7 +260,7 @@ export class EventBusRule<
     scope: Construct,
     id: string,
     bus: IEventBus<T>,
-    predicate?: EventPredicateFunction<T>
+    predicate: EventPredicateFunction<T>
   ) {
     const document = synthesizePatternDocument(predicate as any);
 

--- a/src/event-bridge/transform.ts
+++ b/src/event-bridge/transform.ts
@@ -59,12 +59,12 @@ export class EventBusTransform<T extends EventBusRuleInput, P> {
    *
    * @see EventBusRule.pipe for more details on pipe.
    */
-  pipe<P>(props: LambdaTargetProps<P>): void;
-  pipe<P>(func: Function<P, any>): void;
-  pipe<P>(props: StateMachineTargetProps<P>): void;
-  pipe<P>(props: StepFunction<P, any>): void;
-  pipe<P>(props: ExpressStepFunction<P, any>): void;
-  pipe<P>(
+  pipe(props: LambdaTargetProps<P>): void;
+  pipe(func: Function<P, any>): void;
+  pipe(props: StateMachineTargetProps<P>): void;
+  pipe(props: StepFunction<P, any>): void;
+  pipe(props: ExpressStepFunction<P, any>): void;
+  pipe(
     resource:
       | Function<P, any>
       | LambdaTargetProps<P>

--- a/src/step-function.ts
+++ b/src/step-function.ts
@@ -359,7 +359,7 @@ interface StepFunctionDetail {
   };
 }
 
-interface StepFunctionSucceededEvent
+interface StepFunctionStatusChangedEvent
   extends EventBusRuleInput<
     StepFunctionDetail,
     "Step Functions Execution Status Change",
@@ -537,11 +537,11 @@ abstract class BaseStepFunction<P extends Record<string, any> | undefined, O>
     };
   }
 
-  public onSuccess(
+  public onSucceeded(
     scope: Construct,
     id: string
-  ): EventBusRule<StepFunctionSucceededEvent> {
-    const bus = EventBus.default<StepFunctionSucceededEvent>(this);
+  ): EventBusRule<StepFunctionStatusChangedEvent> {
+    const bus = EventBus.default<StepFunctionStatusChangedEvent>(this);
 
     return new EventBusPredicateRuleBase(
       scope,
@@ -560,11 +560,11 @@ abstract class BaseStepFunction<P extends Record<string, any> | undefined, O>
     );
   }
 
-  public onFailure(
+  public onFailed(
     scope: Construct,
     id: string
-  ): EventBusRule<StepFunctionSucceededEvent> {
-    const bus = EventBus.default<StepFunctionSucceededEvent>(this);
+  ): EventBusRule<StepFunctionStatusChangedEvent> {
+    const bus = EventBus.default<StepFunctionStatusChangedEvent>(this);
 
     return new EventBusPredicateRuleBase(
       scope,
@@ -586,8 +586,8 @@ abstract class BaseStepFunction<P extends Record<string, any> | undefined, O>
   public onStarted(
     scope: Construct,
     id: string
-  ): EventBusRule<StepFunctionSucceededEvent> {
-    const bus = EventBus.default<StepFunctionSucceededEvent>(this);
+  ): EventBusRule<StepFunctionStatusChangedEvent> {
+    const bus = EventBus.default<StepFunctionStatusChangedEvent>(this);
 
     return new EventBusPredicateRuleBase(
       scope,
@@ -609,8 +609,8 @@ abstract class BaseStepFunction<P extends Record<string, any> | undefined, O>
   public onTimedOut(
     scope: Construct,
     id: string
-  ): EventBusRule<StepFunctionSucceededEvent> {
-    const bus = EventBus.default<StepFunctionSucceededEvent>(this);
+  ): EventBusRule<StepFunctionStatusChangedEvent> {
+    const bus = EventBus.default<StepFunctionStatusChangedEvent>(this);
 
     return new EventBusPredicateRuleBase(
       scope,
@@ -632,8 +632,8 @@ abstract class BaseStepFunction<P extends Record<string, any> | undefined, O>
   public onAborted(
     scope: Construct,
     id: string
-  ): EventBusRule<StepFunctionSucceededEvent> {
-    const bus = EventBus.default<StepFunctionSucceededEvent>(this);
+  ): EventBusRule<StepFunctionStatusChangedEvent> {
+    const bus = EventBus.default<StepFunctionStatusChangedEvent>(this);
 
     return new EventBusPredicateRuleBase(
       scope,
@@ -655,11 +655,11 @@ abstract class BaseStepFunction<P extends Record<string, any> | undefined, O>
   /**
    * Create event bus rule that matches any status change on this machine.
    */
-  public onStatusChange(
+  public onStatusChanged(
     scope: Construct,
     id: string
-  ): EventBusRule<StepFunctionSucceededEvent> {
-    const bus = EventBus.default<StepFunctionSucceededEvent>(this);
+  ): EventBusRule<StepFunctionStatusChangedEvent> {
+    const bus = EventBus.default<StepFunctionStatusChangedEvent>(this);
 
     // We are not able to use the nice "when" function here because we don't compile
     return new EventBusPredicateRuleBase(

--- a/test-app/src/message-board.ts
+++ b/test-app/src/message-board.ts
@@ -1,7 +1,6 @@
 import {
   App,
   aws_dynamodb,
-  aws_events,
   aws_lambda,
   RemovalPolicy,
   Stack,
@@ -384,9 +383,7 @@ exports.handler = async (event) => {
   })
 );
 
-const defaultBus = EventBus.fromBus<TestDeleteEvent>(
-  aws_events.EventBus.fromEventBusName(stack, "defaultBus", "default")
-);
+const defaultBus = EventBus.default<TestDeleteEvent>(stack);
 
 deleteWorkflow
   .onSuccess(stack, "deleteSuccessfulEvent")

--- a/test/eventpattern.test.ts
+++ b/test/eventpattern.test.ts
@@ -861,7 +861,6 @@ describe("event pattern", () => {
       );
     });
 
-    // TODO: this should work, invalid ranges should not fail until the end when no range will be valid.
     test("numeric range or and AND part reduced both losing some range", () => {
       ebEventPatternTestCase(
         reflect<EventPredicateFunction<TestEvent>>(
@@ -936,7 +935,6 @@ describe("event pattern", () => {
       );
     });
 
-    // TODO: drop the invalid range.
     test("numeric range or and AND dropped range", () => {
       ebEventPatternTestCase(
         reflect<EventPredicateFunction<TestEvent>>(
@@ -1103,7 +1101,6 @@ describe("event pattern", () => {
       );
     });
 
-    // TODO: only fail when the final state is impossible.
     test("same field AND string with OR", () => {
       ebEventPatternTestCase(
         reflect<EventPredicateFunction<TestEvent>>(
@@ -1119,7 +1116,6 @@ describe("event pattern", () => {
       );
     });
 
-    // TODO fix this
     test("same field AND string identical", () => {
       ebEventPatternTestCase(
         reflect<EventPredicateFunction<TestEvent>>(
@@ -1333,7 +1329,6 @@ describe("event pattern", () => {
       );
     });
 
-    // TODO: this should work
     test("AND not exists and exists impossible", () => {
       ebEventPatternTestCase(
         reflect<EventPredicateFunction<TestEvent>>(

--- a/test/eventpattern.test.ts
+++ b/test/eventpattern.test.ts
@@ -1531,7 +1531,7 @@ describe("event pattern", () => {
 
 // https://github.com/sam-goodwin/functionless/issues/68
 describe.skip("destructure", () => {
-  test("descture parameter", () => {
+  test("destructure parameter", () => {
     ebEventPatternTestCase(
       reflect<EventPredicateFunction<TestEvent>>(
         ({ source }) => source === "lambda"
@@ -1542,7 +1542,7 @@ describe.skip("destructure", () => {
     );
   });
 
-  test("descture variable", () => {
+  test("destructure variable", () => {
     ebEventPatternTestCase(
       reflect<EventPredicateFunction<TestEvent>>((event) => {
         const { source } = event;
@@ -1554,7 +1554,7 @@ describe.skip("destructure", () => {
     );
   });
 
-  test("descture multi-layer variable", () => {
+  test("destructure multi-layer variable", () => {
     ebEventPatternTestCase(
       reflect<EventPredicateFunction<TestEvent>>((event) => {
         const {
@@ -1568,7 +1568,7 @@ describe.skip("destructure", () => {
     );
   });
 
-  test("descture array doesn't work", () => {
+  test("destructure array doesn't work", () => {
     ebEventPatternTestCaseError(
       reflect<EventPredicateFunction<TestEvent>>((event) => {
         const {
@@ -1581,7 +1581,7 @@ describe.skip("destructure", () => {
     );
   });
 
-  test("descture parameter array doesn't work", () => {
+  test("destructure parameter array doesn't work", () => {
     ebEventPatternTestCaseError(
       reflect<EventPredicateFunction<TestEvent>>(
         ({
@@ -1605,7 +1605,7 @@ describe.skip("destructure", () => {
     );
   });
 
-  test("descture parameter rename", () => {
+  test("destructure parameter rename", () => {
     ebEventPatternTestCase(
       reflect<EventPredicateFunction<TestEvent>>(
         ({ source: src }) => src === "lambda"

--- a/test/eventpattern.test.ts
+++ b/test/eventpattern.test.ts
@@ -1616,3 +1616,49 @@ describe.skip("destructure", () => {
     );
   });
 });
+
+// TODO: create ticket
+describe.skip("list some", () => {
+  test("list starts with", () => {
+    ebEventPatternTestCase(
+      reflect<EventPredicateFunction<TestEvent>>((event) =>
+        event.resources.some((r) => r.startsWith("hi"))
+      ),
+      {
+        resources: [{ prefix: "hi" }],
+      }
+    );
+  });
+
+  test("list starts with AND errors", () => {
+    ebEventPatternTestCaseError(
+      reflect<EventPredicateFunction<TestEvent>>((event) =>
+        event.resources.some((r) => r.startsWith("hi") && r === "taco")
+      )
+    );
+  });
+
+  test("list starts with OR is fine", () => {
+    ebEventPatternTestCase(
+      reflect<EventPredicateFunction<TestEvent>>((event) =>
+        event.resources.some(
+          (r) => r.startsWith("hi") || r.startsWith("taco") || r === "cheddar"
+        )
+      ),
+      {
+        resources: [{ prefix: "hi" }, { prefix: "taco" }, "cheddar"],
+      }
+    );
+  });
+
+  test("list some instead of includes", () => {
+    ebEventPatternTestCase(
+      reflect<EventPredicateFunction<TestEvent>>((event) =>
+        event.resources.some((r) => r === "cheddar")
+      ),
+      {
+        resources: ["cheddar"],
+      }
+    );
+  });
+});

--- a/test/step-function.test.ts
+++ b/test/step-function.test.ts
@@ -6033,6 +6033,7 @@ test("on success event", () => {
   const success = machine.onSuccess(stack, "onSuccess");
 
   expect(success.rule._renderEventPattern()).toEqual({
+    source: ["aws.states"],
     "detail-type": ["Step Functions Execution Status Change"],
     detail: {
       status: ["SUCCEEDED"],
@@ -6047,6 +6048,7 @@ test("on status change event", () => {
   const statusChange = machine.onStatusChange(stack, "onSuccess");
 
   expect(statusChange.rule._renderEventPattern()).toEqual({
+    source: ["aws.states"],
     "detail-type": ["Step Functions Execution Status Change"],
     detail: {
       stateMachineArn: [machine.stateMachineArn],
@@ -6062,6 +6064,7 @@ test("on status change event refine", () => {
     .when(stack, "onRunning", (event) => event.detail.status === "RUNNING");
 
   expect(success.rule._renderEventPattern()).toEqual({
+    source: ["aws.states"],
     "detail-type": ["Step Functions Execution Status Change"],
     detail: {
       status: ["RUNNING"],

--- a/test/step-function.test.ts
+++ b/test/step-function.test.ts
@@ -6030,7 +6030,7 @@ test("call Step Function describe from another Step Function from context", () =
 test("on success event", () => {
   const machine = new StepFunction(stack, "machine", () => {});
 
-  const success = machine.onSuccess(stack, "onSuccess");
+  const success = machine.onSucceeded(stack, "onSuccess");
 
   expect(success.rule._renderEventPattern()).toEqual({
     source: ["aws.states"],
@@ -6045,7 +6045,7 @@ test("on success event", () => {
 test("on status change event", () => {
   const machine = new StepFunction(stack, "machine", () => {});
 
-  const statusChange = machine.onStatusChange(stack, "onSuccess");
+  const statusChange = machine.onStatusChanged(stack, "onSuccess");
 
   expect(statusChange.rule._renderEventPattern()).toEqual({
     source: ["aws.states"],
@@ -6060,7 +6060,7 @@ test("on status change event refine", () => {
   const machine = new StepFunction(stack, "machine", () => {});
 
   const success = machine
-    .onStatusChange(stack, "onStatus")
+    .onStatusChanged(stack, "onStatus")
     .when(stack, "onRunning", (event) => event.detail.status === "RUNNING");
 
   expect(success.rule._renderEventPattern()).toEqual({

--- a/test/step-function.test.ts
+++ b/test/step-function.test.ts
@@ -6026,3 +6026,46 @@ test("call Step Function describe from another Step Function from context", () =
     },
   });
 });
+
+test("on success event", () => {
+  const machine = new StepFunction(stack, "machine", () => {});
+
+  const success = machine.onSuccess(stack, "onSuccess");
+
+  expect(success.rule._renderEventPattern()).toEqual({
+    "detail-type": ["Step Functions Execution Status Change"],
+    detail: {
+      status: ["SUCCEEDED"],
+      stateMachineArn: [machine.stateMachineArn],
+    },
+  });
+});
+
+test("on status change event", () => {
+  const machine = new StepFunction(stack, "machine", () => {});
+
+  const statusChange = machine.onStatusChange(stack, "onSuccess");
+
+  expect(statusChange.rule._renderEventPattern()).toEqual({
+    "detail-type": ["Step Functions Execution Status Change"],
+    detail: {
+      stateMachineArn: [machine.stateMachineArn],
+    },
+  });
+});
+
+test("on status change event refine", () => {
+  const machine = new StepFunction(stack, "machine", () => {});
+
+  const success = machine
+    .onStatusChange(stack, "onStatus")
+    .when(stack, "onRunning", (event) => event.detail.status === "RUNNING");
+
+  expect(success.rule._renderEventPattern()).toEqual({
+    "detail-type": ["Step Functions Execution Status Change"],
+    detail: {
+      status: ["RUNNING"],
+      stateMachineArn: [machine.stateMachineArn],
+    },
+  });
+});

--- a/test/util.ts
+++ b/test/util.ts
@@ -12,7 +12,10 @@ import * as appsync from "@aws-cdk/aws-appsync-alpha";
 import path from "path";
 import { Rule } from "aws-cdk-lib/aws-events";
 import { Err, isErr } from "../src/error";
-import { synthesizeEventPattern } from "../src/event-bridge/event-pattern/synth";
+import {
+  synthesizeEventPattern,
+  synthesizePatternDocument,
+} from "../src/event-bridge/event-pattern/synth";
 import { EventTransformFunction } from "../src/event-bridge/transform";
 import { synthesizeEventBridgeTargets } from "../src/event-bridge/target-input";
 import {
@@ -158,7 +161,8 @@ export function ebEventPatternTestCase(
   decl: FunctionDecl | Err,
   expected: FunctionlessEventPattern
 ) {
-  const result = synthesizeEventPattern(decl);
+  const document = synthesizePatternDocument(decl);
+  const result = synthesizeEventPattern(document);
 
   expect(result).toEqual(expected);
 }
@@ -167,7 +171,10 @@ export function ebEventPatternTestCaseError(
   decl: FunctionDecl | Err,
   message?: string
 ) {
-  expect(() => synthesizeEventPattern(decl)).toThrow(message);
+  expect(() => {
+    const document = synthesizePatternDocument(decl);
+    synthesizeEventPattern(document);
+  }).toThrow(message);
 }
 
 let stack: Stack;


### PR DESCRIPTION
Closes #71 Closes #99
Part Of #44 

Depends on PR #100 

* [x] Support Narrowing events in `when` and `map`
* [x] Support refining event bridge events
* [x] Support `on*` events for Step Functions
   * [x] Success
   * [x] Failure
   * [x] Status Changed
   * [x] Started
   * [x] Timeout
   * [x] Aborted

## Narrowing

`when` and `map` now correctly narrow the output type of the rule or transform. `when` narrowing requires type predicates, this is a typescript limitation. `(event): event is Type1 => 'field1' in event`

```ts
interface t1 {
  type: "one",
  value: string
}
interface t2 {
  type: "two",
  value: number
}
interface Event extends EventBusRuleInput<t1|t2>{}
const bus = new EventBus<Event>()

const rule1 = bus.when(this, 'rule1', (event):  event is Event<t1> => event.detail.type === "one" );

rule1.when(this, 'rule2', event => event.detail.value === "hello") // fine, value is a string
rule1.when(this, 'rule3', event => event.detail.value < 100) // fails, value in `t1` is a `string`, not a number
```

## Refining

`when` can now be chained, representing multiple AND type joins.

```ts
interface Event extends EventBusRuleInput<t1|t2>{}
const bus = new EventBus<Event>()

const rule1 = bus.when(this, 'rule1', (event):  event is Event<t1> => event.detail.type === "one" );

// same as `event.detail.type === "one" && event.detail.value === "something" && event.source === "lambda"`
const redined2 = bus
   .when(this, 'refinedRule', (event) => event.detail.value === "something")
   .when(this, 'refinedRule2', (event) => event.source === "lambda")

// both rules can be used
rule1.pipe()
redined2.pipe()
```

If a functionless event bus rule is not used, a CDK rule will not be created.

## On* Event helpers in Step Functions

https://docs.aws.amazon.com/step-functions/latest/dg/cw-events.html#cw-events-events

```ts
const machine = new StepFunction()
machine.onStarted(scope, 'started').pipe(myFunction);

// on failed and refined 
machine.onFailed(scope, 'failed').when(event => event.detail.name.startWith("SensativeEvent")).pipe(errorHandler)

// handle all negative events
machine.onStatusChanged(scope, 'allNegative')
   .when(event => event.detail.status === "FAILED" ||
       event.detail.status === "ABORTED" ||
       event.detail.status === "TIMED_OUT" )
```

BREAKING CHANGE: Event Bridge `pipe`, `when`, and `map` will now respect narrowed and declared types and may fail compilation if incorrectly configured in the past.