### PR TITLE
fix: replace quote logic in ASL

### DIFF
--- a/src/asl.ts
+++ b/src/asl.ts
@@ -1451,7 +1451,7 @@ export namespace ASL {
           );
         }
       } else if (expr.kind === "StringLiteralExpr") {
-        return `'${expr.value.replace("'", "\\\\'")}'`;
+        return `'${expr.value.replace(/'/g, "\\\\'")}'`;
       } else if (
         expr.kind === "BooleanLiteralExpr" ||
         expr.kind === "NumberLiteralExpr" ||


### PR DESCRIPTION
Fixing a simple bug found by snyk. In ASL, single quotes were not being properly replaced when creating JSON Path filter expressions.