### PR TITLE
fix: replace single quotes in JSON Path filter expression with a single backslash

### DIFF
--- a/src/asl.ts
+++ b/src/asl.ts
@@ -1451,7 +1451,7 @@ export namespace ASL {
           );
         }
       } else if (expr.kind === "StringLiteralExpr") {
-        return `'${expr.value.replace(/'/g, "\\\\'")}'`;
+        return `'${expr.value.replace(/'/g, "\\'")}'`;
       } else if (
         expr.kind === "BooleanLiteralExpr" ||
         expr.kind === "NumberLiteralExpr" ||


### PR DESCRIPTION
https://github.com/sam-goodwin/functionless/pull/125 was prematurely merged. It mistakenly used two backslashes instead of one and did not add any tests.